### PR TITLE
[FIX] isItemsEnabled 옵셔널 체이닝 추가 #33

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -27,7 +27,7 @@ const GamePage = () => {
               <VideoChat />
             </div>
             <div className="flex flex-col w-full gap-y-[20px]">
-              {gameState.isItemsEnabled ? (
+              {gameState?.isItemsEnabled ? (
                 <ItemBox onItemClick={setActiveItem} />
               ) : (
                 <div className="h-[150px]"></div>


### PR DESCRIPTION
### 📝 관련 이슈
closed #33 
- 게임방 렌더링 시 isItemsEnabled 타입에러 발생

### ✨ 반영 브랜치

<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->

- FROM: `33-fix/isItemsEnabled`
- TO: `master`

### 💡 재현 과정

Netlify 테스트 배포 채널에서 빌드하는 과정에서 타입에러로 인한 빌드 실패

```
Diagnosis: The build failure is due to a TypeError caused by an issue in the Next.js application while trying to read properties of null related to 'isItemsEnabled'.

Solution:

Navigate to the '/opt/build/repo/.next/server/app/game/page.js' file in the repository.
Locate the code around line 2:976 where the 'isItemsEnabled' property is accessed.
Ensure that the object being referenced is not null before accessing its properties to prevent this TypeError.
Make necessary adjustments to handle null values appropriately to avoid such errors in the future.
This should resolve the TypeError and allow the build to complete successfully.
```

### ✅ 예상하는 정상 작동

`gameState`의 `isItemsEnabled` 값에 접근할 때 옵셔널 체이닝을 사용하여 `null`이거나 `undefined`일 때 발생하는 오류 방지
