### PR TITLE
[FEAT] 아이템 사용 소켓 작업 #35

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
     "Millis",
     "tailwindcss",
     "tseslint",
+    "webp",
     "zustand"
   ]
 }

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useState } from 'react';
-
 import ProtectedRoute from '../../components/ProtectedRoute/ProtectedRoute';
 import ChatBox from '../../features/chat/components/ChatBox';
 import Drawing from '../../features/drawing/components/Drawing';
@@ -12,14 +10,13 @@ import useSocketStore from '../../features/socket/socketStore';
 
 const GamePage = () => {
   const { gameState } = useSocketStore();
-  const [activeItem, setActiveItem] = useState<string | null>(null);
 
   return (
     <ProtectedRoute>
       <div className="flex items-center justify-center min-h-dvh overflow-hidden scrollbar-hide">
         <div className="flex w-full max-w-[1240px] gap-[40px]">
           <div className="flex flex-col left w-full gap-y-[20px]">
-            <Drawing activeItem={activeItem} />
+            <Drawing />
             <ChatBox />
           </div>
           <div className="flex flex-col right w-full max-w-[420px] gap-y-[20px]">
@@ -28,7 +25,7 @@ const GamePage = () => {
             </div>
             <div className="flex flex-col w-full gap-y-[20px]">
               {gameState?.isItemsEnabled ? (
-                <ItemBox onItemClick={setActiveItem} />
+                <ItemBox />
               ) : (
                 <div className="h-[150px]"></div>
               )}

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import ProtectedRoute from '../../components/ProtectedRoute/ProtectedRoute';
 import ChatBox from '../../features/chat/components/ChatBox';
 import Drawing from '../../features/drawing/components/Drawing';
@@ -7,9 +9,15 @@ import GameControlButtons from '../../features/drawing/components/GameControlBut
 import ItemBox from '../../features/drawing/components/ItemBox';
 import VideoChat from '../../features/videoChat/components/VideoChat';
 import useSocketStore from '../../features/socket/socketStore';
+import useItemStore from '../../features/drawing/store/useItemStore';
 
 const GamePage = () => {
   const { gameState } = useSocketStore();
+  const { resetItemUsageState } = useItemStore();
+
+  useEffect(() => {
+    resetItemUsageState();
+  }, []);
 
   return (
     <ProtectedRoute>

--- a/src/features/drawing/components/BombEffect.tsx
+++ b/src/features/drawing/components/BombEffect.tsx
@@ -1,7 +1,19 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 
 const BombEffect: React.FC = () => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsVisible(false);
+    }, 5000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!isVisible) return null;
+
   return (
     <div className="absolute flex items-center justify-center w-full h-full">
       <motion.img

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -12,6 +12,7 @@ import KeywordPlate from '../../../components/KeywordPlate/KeywordPlate';
 import Settings from '../../../components/Settings/Settings';
 import Modal from '../../../components/Modal/Modal';
 import useSocketStore from '../../socket/socketStore';
+import useItemStore from '../store/useItemStore';
 
 type QuizState =
   | 'breakTime'
@@ -55,11 +56,8 @@ const initialGameState = {
     }
   >,
 };
-interface DrawingProps {
-  activeItem: string | null;
-}
 
-const Drawing: React.FC<DrawingProps> = ({ activeItem }) => {
+const Drawing: React.FC = () => {
   const canvasRef = useRef<fabric.Canvas | null>(null);
   const [gameState, setGameState] = useState(initialGameState);
   const [comment, setComment] = useState('');
@@ -81,6 +79,7 @@ const Drawing: React.FC<DrawingProps> = ({ activeItem }) => {
   const [isTimeCut, setIsTimeCut] = useState(false); // Time-Cutter 아이템 사용 여부
 
   const { socket, roomId } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
+  const { activeItem } = useItemStore();
 
   const quizStates: QuizState[] = [
     'drawing',

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -12,7 +12,6 @@ import KeywordPlate from '../../../components/KeywordPlate/KeywordPlate';
 import Settings from '../../../components/Settings/Settings';
 import Modal from '../../../components/Modal/Modal';
 import useSocketStore from '../../socket/socketStore';
-import useItemStore from '../store/useItemStore';
 
 type QuizState =
   | 'breakTime'
@@ -72,14 +71,14 @@ const Drawing: React.FC = () => {
 
   const [imageLoaded, setImageLoaded] = useState(false); // 이미지 로딩 상태 추가
   const [backgroundImage, setBackgroundImage] = useState(''); // 배경 이미지 경로 상태
-  const [isToxicUsed, setIsToxicUsed] = useState(false); // Toxic-Cover 아이템 사용 여부
-  const [isBombUsed, setIsBombUsed] = useState(false); // Growing-Bomb 아이템 사용 여부
-  const [isTextRevers, setIsTextRevers] = useState(false); // Phantom-Reverse 아이템 사용 여부
-  const [isFlipped, setIsFlipped] = useState(false); // Laundry-Flip 아이템 사용 여부
-  const [isTimeCut, setIsTimeCut] = useState(false); // Time-Cutter 아이템 사용 여부
 
-  const { socket, roomId } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
-  const { activeItem } = useItemStore();
+  // TODO: 61번쨰 줄의 gameState 개별관리 코드 없어지면 socketGameState 별칭 지우기
+  const {
+    socket,
+    roomId,
+    gameState: socketGameState,
+    updateGameState,
+  } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
 
   const quizStates: QuizState[] = [
     'drawing',
@@ -438,66 +437,42 @@ const Drawing: React.FC = () => {
   };
 
   useEffect(() => {
-    const updateGameState = itemKey => {
-      setGameState(prevState => ({
-        ...prevState,
-        items: {
-          ...prevState.items,
-          [itemKey]: { ...prevState.items[itemKey], status: true },
-        },
-      }));
+    if (socket) {
+      socket.on('itemUsedUpdate', updatedGameState => {
+        updateGameState(updatedGameState);
+      });
+    }
+
+    return () => {
+      if (socket) socket.off('itemUsedUpdate');
     };
+  }, [updateGameState]);
 
-    if (activeItem === 'Toxic-Cover' && !isToxicUsed) {
-      setIsToxicUsed(true);
-      updateGameState('toxicCover');
-    } else if (activeItem === 'Growing-Bomb' && !isBombUsed) {
-      setIsBombUsed(true);
-      setTimeout(() => {
-        setIsBombUsed(false);
-      }, 5000);
-      updateGameState('growingBomb');
-    } else if (activeItem === 'Phantom-Reverse' && !isTextRevers) {
-      setIsTextRevers(true); // 채팅 반대로 출력 기능
-      updateGameState('phantomReverse');
-    } else if (activeItem === 'Laundry-Flip' && !isFlipped) {
-      if (canvasRef.current) {
-        const canvas = canvasRef.current;
-        canvas.getObjects().forEach(obj => {
-          obj.set('flipY', !obj.flipY); // 현재 상태 반전
-        });
-        canvas.renderAll();
-      }
-      setIsFlipped(true);
-      updateGameState('laundryFlip');
-    } else if (
-      activeItem === 'Time-Cutter' &&
-      !isTimeCut &&
-      remainingTime > 0
-    ) {
-      const newDeadline = Date.now() + (remainingTime * 1000) / 2; // 남은 시간의 반만큼 감소
-      setGameState(prev => ({
-        ...prev,
-        turnDeadline: newDeadline,
-        items: {
-          ...prev.items,
-          timeCutter: { ...prev.items.timeCutter, status: true },
-        },
-      }));
-      setIsTimeCut(true); // Time-Cutter 아이템이 활성화될 때만 true로 설정
-    }
-  }, [activeItem]);
-
-  // 상태 변경 감지하여 drawing 상태가 아닐 때 아이템 효과가 사라지도록 처리(수정 예정)
   useEffect(() => {
-    if (gameState.gameStatus !== 'drawing') {
-      setIsToxicUsed(false);
-      setIsBombUsed(false);
-      setIsTextRevers(false);
-      setIsFlipped(false);
-      setIsTimeCut(false);
+    if (socketGameState?.activeItem) {
+      const { activeItem } = socketGameState;
+
+      if (activeItem === 'LaundryFlip') {
+        if (canvasRef.current) {
+          const canvas = canvasRef.current;
+          canvas.getObjects().forEach(obj => {
+            obj.set('flipY', !obj.flipY); // 현재 상태 반전
+          });
+          canvas.renderAll();
+        }
+      } else if (activeItem === 'TimeCutter' && remainingTime > 0) {
+        const newDeadline = Date.now() + (remainingTime * 1000) / 2; // 남은 시간의 반만큼 감소
+        setGameState(prev => ({
+          ...prev,
+          turnDeadline: newDeadline,
+          items: {
+            ...prev.items,
+            timeCutter: { ...prev.items.timeCutter, status: true },
+          },
+        }));
+      }
     }
-  }, [gameState]);
+  }, [socketGameState]);
 
   // socket으로 clear 전송
   useEffect(() => {
@@ -717,12 +692,8 @@ const Drawing: React.FC = () => {
           className={`rounded-[10px] absolute w-full h-full left-0 top-0 z-10`} // ${isFlipped ? 'transform scale-y-[-1]' : ''}
         />
 
-        {activeItem === 'Toxic-Cover' &&
-          isToxicUsed &&
-          gameState.gameStatus === 'drawing' && <ToxicEffect />}
-        {activeItem === 'Growing-Bomb' &&
-          isBombUsed &&
-          gameState.gameStatus === 'drawing' && <BombEffect />}
+        {socketGameState?.items['ToxicCover']?.status && <ToxicEffect />}
+        {socketGameState?.items['GrowingBomb']?.status && <BombEffect />}
 
         {gameState.gameStatus === 'drawing' ? (
           ''
@@ -821,18 +792,19 @@ const Drawing: React.FC = () => {
           </div>
           {gameState.gameStatus === 'drawing' && (
             <ul className="flex flex-col">
-              {Object.entries(gameState.items).map(
-                ([key, item]) =>
-                  item.status && (
-                    <li key={key}>
-                      <img
-                        src={`/images/drawing/items/${key}.png`}
-                        alt={key}
-                        draggable={false}
-                      />
-                    </li>
-                  )
-              )}
+              {socketGameState &&
+                Object.entries(socketGameState.items).map(
+                  ([key, item]) =>
+                    item.status && (
+                      <li key={key}>
+                        <img
+                          src={`/images/drawing/items/${key}.png`}
+                          alt={key}
+                          draggable={false}
+                        />
+                      </li>
+                    )
+                )}
             </ul>
           )}
         </div>
@@ -841,14 +813,14 @@ const Drawing: React.FC = () => {
             <TimeBar
               duration={remainingTime}
               onComplete={() => console.log('Time Over!')}
-              isTimeCut={isTimeCut}
+              isTimeCut={socketGameState?.items['TimeCutter']?.status}
             />
           )}
           {gameState.gameStatus === 'choosing' && (
             <TimeBar
               duration={5}
               onComplete={() => console.log('Time Over!')}
-              isTimeCut={isTimeCut}
+              isTimeCut={false}
             />
           )}
         </div>

--- a/src/features/drawing/components/ItemBox.tsx
+++ b/src/features/drawing/components/ItemBox.tsx
@@ -40,14 +40,19 @@ const ItemBox: React.FC = () => {
   const onHandleItemClick = (itemId: string) => {
     if (
       !itemUsageState[itemId as keyof typeof itemUsageState] &&
-      !gameState.items[itemId as keyof typeof itemUsageState].status
+      !gameState.items[itemId as keyof typeof itemUsageState].status &&
+      !isAnyItemUsedThisRound
     ) {
-      setItemUsed(itemId as keyof typeof itemUsageState);
+      setItemUsed(itemId as keyof typeof itemUsageState, gameState.round);
 
       if (socket) socket.emit('itemUsed', roomId, itemId);
     }
   };
   // Todo: 총 라운드가 끝나면 아이템 상태 초기화
+
+  const isAnyItemUsedThisRound = Object.values(itemUsageState).some(
+    item => item !== null && item === gameState.round
+  );
 
   return (
     <div className="relative flex flex-col items-center justify-center bg-primary-default p-4 rounded-lg border-black border-[4px] drop-shadow-drawing z-20">
@@ -76,9 +81,11 @@ const ItemBox: React.FC = () => {
               draggable={false}
             />
 
-            {gameState.items[item.id as keyof typeof itemUsageState].status && (
+            {(gameState.items[item.id as keyof typeof itemUsageState].status ||
+              isAnyItemUsedThisRound) && (
               <div className="absolute inset-0 flex items-center justify-center bg-black/60">
-                {itemUsageState[item.id as keyof typeof itemUsageState] && (
+                {itemUsageState[item.id as keyof typeof itemUsageState] !==
+                  null && (
                   <img
                     src="/images/drawing/inactiveCross.png"
                     alt="inactive"

--- a/src/features/drawing/components/ItemBox.tsx
+++ b/src/features/drawing/components/ItemBox.tsx
@@ -2,30 +2,31 @@ import React, { useState } from 'react';
 
 import SpeechBubble from '../../../components/SpeechBubble/SpeechBubble';
 import useItemStore from '../store/useItemStore';
+import useSocketStore from '../../socket/socketStore';
 
 const items = [
   {
-    id: 'Toxic-Cover',
+    id: 'ToxicCover',
     image: '/images/drawing/items/toxicCover.png',
     description: '군데군데 독극물을 뿌린다.',
   },
   {
-    id: 'Growing-Bomb',
+    id: 'GrowingBomb',
     image: '/images/drawing/items/growingBomb.png',
     description: '5초간 폭발이 발생한다.',
   },
   {
-    id: 'Phantom-Reverse',
+    id: 'PhantomReverse',
     image: '/images/drawing/items/phantomReverse.png',
     description: '글자를 거꾸로 입력한다.',
   },
   {
-    id: 'Laundry-Flip',
+    id: 'LaundryFlip',
     image: '/images/drawing/items/laundryFlip.png',
     description: '그림을 뒤집는다.',
   },
   {
-    id: 'Time-Cutter',
+    id: 'TimeCutter',
     image: '/images/drawing/items/timeCutter.png',
     description: '시간의 반을 먹어치운다.',
   },
@@ -33,12 +34,17 @@ const items = [
 
 const ItemBox: React.FC = () => {
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
-  const { itemUsageState, setItemUsed, setActiveItem } = useItemStore();
+  const { socket, roomId, gameState } = useSocketStore();
+  const { itemUsageState, setItemUsed } = useItemStore();
 
   const onHandleItemClick = (itemId: string) => {
-    if (!itemUsageState[itemId as keyof typeof itemUsageState]) {
+    if (
+      !itemUsageState[itemId as keyof typeof itemUsageState] &&
+      !gameState.items[itemId as keyof typeof itemUsageState].status
+    ) {
       setItemUsed(itemId as keyof typeof itemUsageState);
-      setActiveItem(itemId as keyof typeof itemUsageState);
+
+      if (socket) socket.emit('itemUsed', roomId, itemId);
     }
   };
   // Todo: 총 라운드가 끝나면 아이템 상태 초기화
@@ -69,15 +75,19 @@ const ItemBox: React.FC = () => {
               className="w-full h-full object-contain"
               draggable={false}
             />
-            {itemUsageState[item.id as keyof typeof itemUsageState] ? (
+
+            {gameState.items[item.id as keyof typeof itemUsageState].status && (
               <div className="absolute inset-0 flex items-center justify-center bg-black/60">
-                <img
-                  src="/images/drawing/inactiveCross.png"
-                  alt="inactive"
-                  draggable={false}
-                />
+                {itemUsageState[item.id as keyof typeof itemUsageState] && (
+                  <img
+                    src="/images/drawing/inactiveCross.png"
+                    alt="inactive"
+                    draggable={false}
+                  />
+                )}
               </div>
-            ) : null}
+            )}
+
             {hoveredItem === item.id && (
               <SpeechBubble isAvatarSelected={false} title={item.id}>
                 {item.description}

--- a/src/features/drawing/components/ItemBox.tsx
+++ b/src/features/drawing/components/ItemBox.tsx
@@ -1,52 +1,44 @@
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 import SpeechBubble from '../../../components/SpeechBubble/SpeechBubble';
+import useItemStore from '../store/useItemStore';
 
 const items = [
   {
     id: 'Toxic-Cover',
     image: '/images/drawing/items/toxicCover.png',
-    isActive: true,
     description: '군데군데 독극물을 뿌린다.',
   },
   {
     id: 'Growing-Bomb',
     image: '/images/drawing/items/growingBomb.png',
-    isActive: true,
     description: '5초간 폭발이 발생한다.',
   },
   {
     id: 'Phantom-Reverse',
     image: '/images/drawing/items/phantomReverse.png',
-    isActive: true,
     description: '글자를 거꾸로 입력한다.',
   },
   {
     id: 'Laundry-Flip',
     image: '/images/drawing/items/laundryFlip.png',
-    isActive: true,
     description: '그림을 뒤집는다.',
   },
   {
     id: 'Time-Cutter',
     image: '/images/drawing/items/timeCutter.png',
-    isActive: true,
     description: '시간의 반을 먹어치운다.',
   },
 ];
 
-const ItemBox = ({
-  onItemClick,
-}: {
-  onItemClick: (itemId: string) => void;
-}) => {
+const ItemBox: React.FC = () => {
   const [hoveredItem, setHoveredItem] = useState<string | null>(null);
-  const [usedItems, setUsedItems] = useState<string[]>([]); // 사용된 아이템 목록
+  const { itemUsageState, setItemUsed, setActiveItem } = useItemStore();
 
   const onHandleItemClick = (itemId: string) => {
-    if (!usedItems.includes(itemId)) {
-      setUsedItems([...usedItems, itemId]);
-      onItemClick(itemId); // 클릭된 아이템 ID를 부모 컴포넌트로 전달
+    if (!itemUsageState[itemId as keyof typeof itemUsageState]) {
+      setItemUsed(itemId as keyof typeof itemUsageState);
+      setActiveItem(itemId as keyof typeof itemUsageState);
     }
   };
   // Todo: 총 라운드가 끝나면 아이템 상태 초기화
@@ -77,15 +69,8 @@ const ItemBox = ({
               className="w-full h-full object-contain"
               draggable={false}
             />
-            {!item.isActive || usedItems.includes(item.id) ? (
-              <div
-                className="absolute inset-0 flex items-center justify-center"
-                style={{
-                  background: usedItems.includes(item.id)
-                    ? 'rgba(0, 0, 0, 0.6)'
-                    : 'rgba(0, 0, 0, 0.2)',
-                }}
-              >
+            {itemUsageState[item.id as keyof typeof itemUsageState] ? (
+              <div className="absolute inset-0 flex items-center justify-center bg-black/60">
                 <img
                   src="/images/drawing/inactiveCross.png"
                   alt="inactive"

--- a/src/features/drawing/store/useItemStore.ts
+++ b/src/features/drawing/store/useItemStore.ts
@@ -9,15 +9,12 @@ interface ItemUsageState {
 }
 
 interface ItemStore {
-  activeItem: string | null;
   itemUsageState: ItemUsageState;
-  setActiveItem: (itemId: string) => void;
   setItemUsed: (itemId: keyof ItemUsageState) => void;
   resetItemUsageState: () => void;
 }
 
 const useItemStore = create<ItemStore>(set => ({
-  activeItem: null,
   itemUsageState: {
     ToxicCover: false,
     GrowingBomb: false,
@@ -25,7 +22,6 @@ const useItemStore = create<ItemStore>(set => ({
     LaundryFlip: false,
     TimeCutter: false,
   },
-  setActiveItem: itemId => set({ activeItem: itemId }),
   setItemUsed: itemId =>
     set(state => ({
       itemUsageState: {

--- a/src/features/drawing/store/useItemStore.ts
+++ b/src/features/drawing/store/useItemStore.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+
+interface ItemUsageState {
+  ToxicCover: boolean;
+  GrowingBomb: boolean;
+  PhantomReverse: boolean;
+  LaundryFlip: boolean;
+  TimeCutter: boolean;
+}
+
+interface ItemStore {
+  activeItem: string | null;
+  itemUsageState: ItemUsageState;
+  setActiveItem: (itemId: string) => void;
+  setItemUsed: (itemId: keyof ItemUsageState) => void;
+  resetItemUsageState: () => void;
+}
+
+const useItemStore = create<ItemStore>(set => ({
+  activeItem: null,
+  itemUsageState: {
+    ToxicCover: false,
+    GrowingBomb: false,
+    PhantomReverse: false,
+    LaundryFlip: false,
+    TimeCutter: false,
+  },
+  setActiveItem: itemId => set({ activeItem: itemId }),
+  setItemUsed: itemId =>
+    set(state => ({
+      itemUsageState: {
+        ...state.itemUsageState,
+        [itemId]: true,
+      },
+    })),
+  resetItemUsageState: () =>
+    set({
+      itemUsageState: {
+        ToxicCover: false,
+        GrowingBomb: false,
+        PhantomReverse: false,
+        LaundryFlip: false,
+        TimeCutter: false,
+      },
+    }),
+}));
+
+export default useItemStore;

--- a/src/features/drawing/store/useItemStore.ts
+++ b/src/features/drawing/store/useItemStore.ts
@@ -1,42 +1,42 @@
 import { create } from 'zustand';
 
 interface ItemUsageState {
-  ToxicCover: boolean;
-  GrowingBomb: boolean;
-  PhantomReverse: boolean;
-  LaundryFlip: boolean;
-  TimeCutter: boolean;
+  ToxicCover: number | null;
+  GrowingBomb: number | null;
+  PhantomReverse: number | null;
+  LaundryFlip: number | null;
+  TimeCutter: number | null;
 }
 
 interface ItemStore {
   itemUsageState: ItemUsageState;
-  setItemUsed: (itemId: keyof ItemUsageState) => void;
+  setItemUsed: (itemId: keyof ItemUsageState, round: number) => void;
   resetItemUsageState: () => void;
 }
 
 const useItemStore = create<ItemStore>(set => ({
   itemUsageState: {
-    ToxicCover: false,
-    GrowingBomb: false,
-    PhantomReverse: false,
-    LaundryFlip: false,
-    TimeCutter: false,
+    ToxicCover: null,
+    GrowingBomb: null,
+    PhantomReverse: null,
+    LaundryFlip: null,
+    TimeCutter: null,
   },
-  setItemUsed: itemId =>
+  setItemUsed: (itemId, round) =>
     set(state => ({
       itemUsageState: {
         ...state.itemUsageState,
-        [itemId]: true,
+        [itemId]: round,
       },
     })),
   resetItemUsageState: () =>
     set({
       itemUsageState: {
-        ToxicCover: false,
-        GrowingBomb: false,
-        PhantomReverse: false,
-        LaundryFlip: false,
-        TimeCutter: false,
+        ToxicCover: null,
+        GrowingBomb: null,
+        PhantomReverse: null,
+        LaundryFlip: null,
+        TimeCutter: null,
       },
     }),
 }));

--- a/src/features/socket/socketStore.ts
+++ b/src/features/socket/socketStore.ts
@@ -24,6 +24,7 @@ interface GameState {
   turnDeadline: number | null;
   correctAnswerCount: number;
   isItemsEnabled: boolean;
+  activeItem: string;
   items: Record<string, { user: string | null; status: boolean }>;
   order: string[];
   participants: Record<string, Participant>;
@@ -40,6 +41,7 @@ interface SocketStore {
     roomInfo?: { rounds: number; topic: string; isItemsEnabled: boolean }
   ) => void;
   disconnectSocket: () => void;
+  updateGameState: (updatedGameState: GameState) => void;
 }
 
 const useSocketStore = create<SocketStore>((set, get) => ({
@@ -75,6 +77,10 @@ const useSocketStore = create<SocketStore>((set, get) => ({
       socket.disconnect();
       set({ socket: null, roomId: null, gameState: null });
     }
+  },
+
+  updateGameState: updatedGameState => {
+    set({ gameState: updatedGameState });
   },
 }));
 


### PR DESCRIPTION
### 📝 관련 이슈
closed #35 

### ✨ 반영 브랜치
- FROM: `35-feat/item-socket`
- TO: `master`

### ✅ PR 내용
- [x] 유저별 아이템 사용여부 상태관리 (`useItemStore`)
  > - `zustand`를 이용해 전체 라운드에서 사용한 유저의 아이템 상태를 관리합니다.
  > - 유저는 한 라운드 당 아이템 한개만 사용할 수 있고, 이전 라운드에서 사용한 아이템은 재사용할 수 없고, 해당 턴에서 다른 유저가 사용한 아이템도 사용할 수 없습니다.
  > - `ItemUsageState`의 아이템별 값에 해당 아이템을 사용한 라운드 번호를 저장해서 아이템 사용여부를 판단합니다.
  ```
  interface ItemUsageState {
    ToxicCover: number | null;
    GrowingBomb: number | null;
    PhantomReverse: number | null;
    LaundryFlip: number | null;
    TimeCutter: number | null;
  }
  ```

- [x] `ItemBox`에서 아이템 상태(`used` & `disabled`) 분리
  > - `ItemBox` 컴포넌트에서 개별 상태로 관리되던 부분들을 `useSocketStore`와 `useItemStore` 값으로 수정합니다.
  > - `itemId`의 네이밍 컨벤션을 `gameState`에 맞춰 파스칼케이스로 변경합니다.
  > - 아이템을 클릭하면 이전 라운드에서 사용한 적 없는 아이템인지, 해당 턴에서 다른 유저가 사용한 적 없는 아이템인지, 해당 라운드에서 유저가 사용한 다른 아이템이 없는지 3가지 조건을 확인 후 useSocketStore에 값을 업데이트하고 서버로 소켓이벤트를 전송합니다.
  > - `ItemBox`의 UI를 유저가 사용한 적 있는 아이템(빨간색 X 표시)과 아이템을 사용할 수 없는 상태(검은색 레이어)로 분리합니다.
  ```
  const onHandleItemClick = (itemId: string) => {
    if (
      !itemUsageState[itemId as keyof typeof itemUsageState] &&
      !gameState.items[itemId as keyof typeof itemUsageState].status &&
      !isAnyItemUsedThisRound
    ) {
      setItemUsed(itemId as keyof typeof itemUsageState, gameState.round);

      if (socket) socket.emit('itemUsed', roomId, itemId);
    }
  };
  ```

- [x] `useSocketStore`에 `activeItem` 추가 및 `updateGameState` 메서드 추가
  > - 아이템 효과 발생시점을 서버에서 클라이언트로 받아오는 값인 `activeItem`을 추가합니다.
  > - 서버에서 바뀐 `gameState` 값을 받아서 `useSocketStore`의 `gameState`에 업데이트할 `updateGameState` 메서드를 추가합니다. 클라이언트에서 유저의 액션으로 이벤트가 발생하면 서버로 소켓이벤트를 전송하고, 해당 이벤트를 받은 서버는 `gameState`를 수정한 후 바뀐 `gameState`를 다시 클라이언트로 소켓이벤트 전송하여 모든 유저가 전역관리 중인 `useSocketStore` 값을 동기화시켜서 화면에 렌더링합니다.

- [x] `BombEffect`에서 5초 아이템 효과 발동 시간 설정
  > - 부모 컴포넌트인 `Drawing`에서 설정했던 `setTimeOut` 함수를 `BombEffect` 내부로 이동합니다.
  > - `isVisible` 상태를 이용해 `BombEffect` 첫 렌더링 시 5초간 보여준 후 언마운트합니다.
  ```
  const [isVisible, setIsVisible] = useState(true);

  useEffect(() => {
    const timer = setTimeout(() => {
      setIsVisible(false);
    }, 5000);

    return () => clearTimeout(timer);
  }, []);

  if (!isVisible) return null;
  ```

- [x] 게임방 페이지 내 컴포넌트에서 `useSocketStore` 적용
  > - 개별 상태관리되던 값들을 `useSocketStore`의 상태값으로 수정하여 게임방에 참여한 유저들끼리 동일한 상태를 공유하도록 동기화합니다.


### 🌐 테스트 배포
- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
  > - 테스트 배포 주소: https://sm.doodleplay.xyz/
  > - 테스트 환경 (OS): MacOS
  > - 테스트 환경 (Browser): Chrome / Safari / Firefox / Edge

### 📌 ETC
- 관련 서버 레포지토리: [[FEAT] 아이템 사용 소켓 작업 #8](https://github.com/DoodlePlay/Server/pull/10)
- 서버 레포지토리 merge 전에는 테스트 배포 채널에서 아이템 관련 확인이 불가능합니다!
