### PR TITLE
[FEAT] 게임 진행 우선 소켓 작업 #31

### DIFF
--- a/src/components/KeywordPlate/KeywordPlate.tsx
+++ b/src/components/KeywordPlate/KeywordPlate.tsx
@@ -1,16 +1,26 @@
 import React from 'react';
 
+import useSocketStore from '../../features/socket/socketStore';
+
 interface KeywordPlateProps {
   title: string;
   isChoosing: boolean;
 }
 
 const KeywordPlate: React.FC<KeywordPlateProps> = ({ title, isChoosing }) => {
+  const { socket, roomId } = useSocketStore();
+
+  const onWordClick = () => {
+    if (isChoosing && socket && roomId) {
+      socket.emit('chooseWord', roomId, title);
+    }
+  };
   return (
     <div
       className={`flex items-center justify-center bg-white rounded-[5px] drop-shadow-namePlate max-w-xs p-[5px] border-2 border-neutral-default ${
         isChoosing ? `cursor-pointer` : ''
       }`}
+      onClick={onWordClick}
     >
       <div className="border-2 border-primary-default p-2 flex w-full rounded-[5px] items-center justify-center py-[10px]">
         <span className="text-black font-bold text-4xl">{title}</span>

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -131,8 +131,6 @@ const Drawing: React.FC<DrawingProps> = ({ activeItem }) => {
   useEffect(() => {
     const handleResize = () => {
       const viewportHeight = window.innerHeight;
-
-      // 리사이즈 전에 현재 캔버스 상태를 저장
       const savedCanvas = saveCanvasObjects();
 
       if (viewportHeight <= 1000) {
@@ -155,9 +153,11 @@ const Drawing: React.FC<DrawingProps> = ({ activeItem }) => {
       }, 0); // 지연 시간 제거
     };
 
+    handleResize();
+
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
-  }, [canvasSize]);
+  }, []);
 
   useEffect(() => {
     if (canvasRef.current) {

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -13,52 +13,9 @@ import Settings from '../../../components/Settings/Settings';
 import Modal from '../../../components/Modal/Modal';
 import useSocketStore from '../../socket/socketStore';
 
-type QuizState =
-  | 'breakTime'
-  | 'timeOver'
-  | 'success'
-  | 'waiting'
-  | 'choosing'
-  | 'drawing'
-  | 'create';
-
-const initialGameState = {
-  host: '',
-  gameStatus: 'create' as QuizState,
-  currentDrawer: '22202',
-  currentWord: '사자',
-  totalWords: ['사자', '호랑이' /* ... 추가적인 단어들 */],
-  selectedWords: [] as string[],
-  isWordSelected: false,
-  selectionDeadline: null as number | null,
-  maxRound: 3,
-  round: 3,
-  turn: 1,
-  turnDeadline: Date.now() + (3 / 2) * 60 * 1000,
-  correctAnswerCount: 0,
-  items: {
-    toxicCover: { user: null, status: false },
-    growingBomb: { user: null, status: false },
-    phantomReverse: { user: null, status: false },
-    laundryFlip: { user: null, status: false },
-    timeCutter: { user: null, status: false },
-  },
-  order: [] as string[],
-  participants: {} as Record<
-    string,
-    {
-      nickname: string;
-      score: number;
-      clickedAvatarIndex: string;
-      isVideoOn: boolean;
-      isFlipped: boolean;
-    }
-  >,
-};
-
 const Drawing: React.FC = () => {
   const canvasRef = useRef<fabric.Canvas | null>(null);
-  const [gameState, setGameState] = useState(initialGameState);
+  // const [gameState, setGameState] = useState(initialGameState);
   const [comment, setComment] = useState('');
   const [selectedTool, setSelectedTool] = useState<
     'pencil' | 'eraser' | 'square' | 'paint' | 'circle' | 'clear'
@@ -72,22 +29,8 @@ const Drawing: React.FC = () => {
   const [imageLoaded, setImageLoaded] = useState(false); // 이미지 로딩 상태 추가
   const [backgroundImage, setBackgroundImage] = useState(''); // 배경 이미지 경로 상태
 
-  // TODO: 61번쨰 줄의 gameState 개별관리 코드 없어지면 socketGameState 별칭 지우기
-  const {
-    socket,
-    roomId,
-    gameState: socketGameState,
-    updateGameState,
-  } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
-
-  const quizStates: QuizState[] = [
-    'drawing',
-    'breakTime',
-    'timeOver',
-    'success',
-    'waiting',
-    'choosing',
-  ];
+  // TODO: 61번쨰 줄의 gameState 개별관리 코드 없어지면 gameState 별칭 지우기
+  const { socket, roomId, gameState, updateGameState } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
 
   // 캔버스를 초기화하고, 선택된 도구에 맞게 브러시 설정
   useEffect(() => {
@@ -103,7 +46,7 @@ const Drawing: React.FC = () => {
     return () => {
       canvas.dispose();
     };
-  }, [canvasSize]);
+  }, [canvasSize, gameState?.gameStatus]);
 
   // 모든 객체 선택을 비활성화
   const disableObjectSelection = () => {
@@ -376,19 +319,17 @@ const Drawing: React.FC = () => {
   // TODO : case가 status인데, 추후 조건 변경 status = 'waiting', 'choosing', 'drawing' 3가지로 구분
   const updateBackgroundImage = () => {
     let imgPath = '';
-    switch (gameState.gameStatus) {
-      case 'breakTime':
-        imgPath = '/images/drawing/breakTime.png';
-        break;
-      case 'timeOver':
-        imgPath = '/images/drawing/timeOver.png';
-        break;
-      case 'success':
-        imgPath = '/images/drawing/success.png';
-        break;
+    switch (gameState?.gameStatus) {
       case 'waiting':
         imgPath = '/images/drawing/waiting.png';
         break;
+      case 'choosing':
+        imgPath =
+          gameState?.currentDrawer !== socket?.id &&
+          '/images/drawing/breakTime.png';
+        break;
+      case 'drawing':
+        imgPath = '/images/drawing/breakTime.png';
       default:
         imgPath = '';
     }
@@ -398,41 +339,19 @@ const Drawing: React.FC = () => {
 
   useEffect(() => {
     updateBackgroundImage();
-  }, [gameState.gameStatus]);
+  }, [gameState]);
 
   // 게임 상태에 따라 화면에 보여줄 메시지 업데이트
   useEffect(() => {
-    if (gameState.gameStatus === 'timeOver') {
-      //gameState.gameStatus === 'choosing' && gameState.isWordSelected === false
-      setComment("Time's up");
-    } else if (gameState.gameStatus === 'breakTime') {
-      setComment('Break Time');
-    } else if (gameState.gameStatus === 'choosing') {
+    if (
+      gameState?.gameStatus === 'choosing' &&
+      gameState?.currentDrawer === socket?.id
+    ) {
       setComment('Choose a word');
     } else {
-      setComment('');
+      setComment('Break Time');
     }
-  }, [gameState.gameStatus]);
-
-  // 게임 상태 변경
-  const onStateChange = () => {
-    const currentIndex = quizStates.indexOf(gameState.gameStatus);
-    const nextIndex = (currentIndex + 1) % quizStates.length;
-    const newTurnDeadline = Date.now() + (3 / 2) * 60 * 1000; // 현재 시간에서 1분30초 후
-
-    setGameState(prev => ({
-      ...prev,
-      gameStatus: quizStates[nextIndex],
-      turnDeadline: newTurnDeadline,
-    }));
-
-    canvasRef.current.clear();
-  };
-
-  // 현재 시간과 타임바 종료 시간 계산
-  const remainingTime = gameState.turnDeadline
-    ? Math.max(0, Math.floor((gameState.turnDeadline - Date.now()) / 1000))
-    : 0;
+  }, [gameState]);
 
   const onImageLoad = () => {
     setImageLoaded(true);
@@ -451,8 +370,8 @@ const Drawing: React.FC = () => {
   }, [updateGameState]);
 
   useEffect(() => {
-    if (socketGameState?.activeItem) {
-      const { activeItem } = socketGameState;
+    if (gameState?.activeItem) {
+      const { activeItem } = gameState;
 
       if (activeItem === 'LaundryFlip') {
         if (canvasRef.current) {
@@ -462,19 +381,9 @@ const Drawing: React.FC = () => {
           });
           canvas.renderAll();
         }
-      } else if (activeItem === 'TimeCutter' && remainingTime > 0) {
-        const newDeadline = Date.now() + (remainingTime * 1000) / 2; // 남은 시간의 반만큼 감소
-        setGameState(prev => ({
-          ...prev,
-          turnDeadline: newDeadline,
-          items: {
-            ...prev.items,
-            timeCutter: { ...prev.items.timeCutter, status: true },
-          },
-        }));
       }
     }
-  }, [socketGameState]);
+  }, [gameState]);
 
   // socket으로 clear 전송
   useEffect(() => {
@@ -667,7 +576,14 @@ const Drawing: React.FC = () => {
       canvas.off('mouse:up');
       socket.off('drawingData');
     };
-  }, [socket, roomId, selectedColor, selectedSize, selectedTool, quizStates]); // TODO: 상태 정의
+  }, [
+    socket,
+    roomId,
+    selectedColor,
+    selectedSize,
+    selectedTool,
+    gameState?.gameStatus,
+  ]); // TODO: 상태 정의
 
   return (
     <div className="relative rounded-[10px] p-[20px] border-[4px] border-black drop-shadow-drawing bg-white">
@@ -680,14 +596,11 @@ const Drawing: React.FC = () => {
         />
       </h1>
       {/* 정답 단어 KeywordPlate */}
-      {gameState.currentDrawer &&
-        gameState.currentWord && // TODO : 그림 그리는 사람만 보여지기
-        gameState.gameStatus === 'drawing' && (
+      {gameState?.currentDrawer === socket?.id &&
+        gameState?.currentWord && // TODO : 그림 그리는 사람만 보여지기
+        gameState?.gameStatus === 'drawing' && (
           <div className="max-w-[40%] absolute top-[40px] left-0 right-0 m-auto text-center z-[20] opacity-[0.9]">
-            <KeywordPlate
-              title={socketGameState?.currentWord}
-              isChoosing={false}
-            />
+            <KeywordPlate title={gameState?.currentWord} isChoosing={false} />
           </div>
         )}
 
@@ -697,16 +610,16 @@ const Drawing: React.FC = () => {
           className={`rounded-[10px] absolute w-full h-full left-0 top-0 z-10`} // ${isFlipped ? 'transform scale-y-[-1]' : ''}
         />
 
-        {socketGameState?.items['ToxicCover']?.status && <ToxicEffect />}
-        {socketGameState?.items['GrowingBomb']?.status && <BombEffect />}
+        {gameState?.items['ToxicCover']?.status && <ToxicEffect />}
+        {gameState?.items['GrowingBomb']?.status && <BombEffect />}
 
-        {gameState.gameStatus === 'drawing' ? (
+        {gameState?.gameStatus === 'drawing' ? (
           ''
         ) : (
           <div
             style={{
               background: `${
-                gameState.gameStatus === 'waiting' && imageLoaded
+                gameState?.gameStatus === 'waiting' && imageLoaded
                   ? 'linear-gradient(180deg, rgba(34,139,34,1) 0%, rgba(187,230,187,1) 30%, rgba(220,215,96,1) 60%, rgba(255,199,0,1) 100%)'
                   : ''
               }`,
@@ -723,7 +636,7 @@ const Drawing: React.FC = () => {
             />
             {imageLoaded && (
               <>
-                {gameState.gameStatus === 'waiting' ? (
+                {gameState?.gameStatus === 'waiting' ? (
                   <NamePlate
                     title="winner"
                     score={200}
@@ -738,17 +651,20 @@ const Drawing: React.FC = () => {
               </>
             )}
 
-            {gameState.gameStatus === 'choosing' && (
+            {gameState?.gameStatus === 'choosing' &&
+            gameState?.currentDrawer === socket?.id ? (
               <>
                 <p className="text-center font-cherry text-secondary-default text-6xl">
                   {comment}
                 </p>
                 <div className="flex space-x-4 mt-4">
-                  {socketGameState?.selectedWords.map((word, index) => (
+                  {gameState?.selectedWords.map((word, index) => (
                     <KeywordPlate key={index} title={word} isChoosing />
                   ))}
                 </div>
               </>
+            ) : (
+              <></>
             )}
           </div>
         )}
@@ -757,9 +673,8 @@ const Drawing: React.FC = () => {
             isToolbar ? '' : '-translate-x-full -ml-[25px]'
           } flex justify-between absolute top-0 left-0 z-10 duration-700`}
         >
-          {gameState.currentDrawer &&
-            gameState.gameStatus === 'drawing' &&
-            gameState.currentDrawer && ( // TODO : 그림 그리는 사람만 보여지기
+          {gameState?.gameStatus === 'drawing' &&
+            gameState?.currentDrawer === socket?.id && ( // TODO : 그림 그리는 사람만 보여지기
               <>
                 <Toolbar
                   selectedTool={selectedTool}
@@ -795,10 +710,10 @@ const Drawing: React.FC = () => {
               draggable={false}
             />
           </div>
-          {gameState.gameStatus === 'drawing' && (
+          {gameState?.gameStatus === 'drawing' && (
             <ul className="flex flex-col">
-              {socketGameState &&
-                Object.entries(socketGameState.items).map(
+              {gameState &&
+                Object.entries(gameState?.items).map(
                   ([key, item]) =>
                     item.status && (
                       <li key={key}>
@@ -814,14 +729,14 @@ const Drawing: React.FC = () => {
           )}
         </div>
         <div className="w-full max-w-[740px] absolute left-0 right-0 bottom-[20px] m-auto z-20">
-          {gameState.gameStatus === 'drawing' && (
+          {gameState?.gameStatus === 'drawing' && (
             <TimeBar
-              duration={remainingTime}
+              duration={90}
               onComplete={() => console.log('Time Over!')}
-              isTimeCut={socketGameState?.items['TimeCutter']?.status}
+              isTimeCut={gameState?.items['TimeCutter']?.status}
             />
           )}
-          {gameState.gameStatus === 'choosing' && (
+          {gameState?.gameStatus === 'choosing' && (
             <TimeBar
               duration={5}
               onComplete={() => console.log('Time Over!')}
@@ -837,13 +752,6 @@ const Drawing: React.FC = () => {
       >
         <Settings />
       </Modal>
-      {/* 상태 변경 버튼 */}
-      <button
-        onClick={onStateChange}
-        className="fixed bottom-20 right-10 bg-blue-500 text-white p-2 rounded z-50"
-      >
-        Change State
-      </button>
     </div>
   );
 };

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -373,20 +373,21 @@ const Drawing: React.FC = () => {
   }, []);
 
   // 게임 상태에 따른 배경 이미지 업데이트
+  // TODO : case가 status인데, 추후 조건 변경 status = 'waiting', 'choosing', 'drawing' 3가지로 구분
   const updateBackgroundImage = () => {
     let imgPath = '';
     switch (gameState.gameStatus) {
       case 'breakTime':
-        imgPath = '/images/drawing/breakTime.webp';
+        imgPath = '/images/drawing/breakTime.png';
         break;
       case 'timeOver':
-        imgPath = '/images/drawing/timeOver.webp';
+        imgPath = '/images/drawing/timeOver.png';
         break;
       case 'success':
-        imgPath = '/images/drawing/success.webp';
+        imgPath = '/images/drawing/success.png';
         break;
       case 'waiting':
-        imgPath = '/images/drawing/waiting.webp';
+        imgPath = '/images/drawing/waiting.png';
         break;
       default:
         imgPath = '';
@@ -402,6 +403,7 @@ const Drawing: React.FC = () => {
   // 게임 상태에 따라 화면에 보여줄 메시지 업데이트
   useEffect(() => {
     if (gameState.gameStatus === 'timeOver') {
+      //gameState.gameStatus === 'choosing' && gameState.isWordSelected === false
       setComment("Time's up");
     } else if (gameState.gameStatus === 'breakTime') {
       setComment('Break Time');
@@ -682,7 +684,10 @@ const Drawing: React.FC = () => {
         gameState.currentWord && // TODO : 그림 그리는 사람만 보여지기
         gameState.gameStatus === 'drawing' && (
           <div className="max-w-[40%] absolute top-[40px] left-0 right-0 m-auto text-center z-[20] opacity-[0.9]">
-            <KeywordPlate title={gameState.currentWord} isChoosing={false} />
+            <KeywordPlate
+              title={socketGameState?.currentWord}
+              isChoosing={false}
+            />
           </div>
         )}
 
@@ -739,7 +744,7 @@ const Drawing: React.FC = () => {
                   {comment}
                 </p>
                 <div className="flex space-x-4 mt-4">
-                  {gameState.totalWords.map((word, index) => (
+                  {socketGameState?.selectedWords.map((word, index) => (
                     <KeywordPlate key={index} title={word} isChoosing />
                   ))}
                 </div>

--- a/src/features/drawing/components/GameControlButtons.tsx
+++ b/src/features/drawing/components/GameControlButtons.tsx
@@ -9,12 +9,13 @@ import useSocketStore from '../../socket/socketStore';
 
 const GameControlButtons = () => {
   const router = useRouter();
-  const { disconnectSocket } = useSocketStore();
+  const { disconnectSocket, socket, roomId } = useSocketStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const onStartGame = () => {
-    console.log('Game started');
-    // 게임 시작 로직을 여기에 추가합니다.
+    if (socket && roomId) {
+      socket.emit('startGame', roomId);
+    }
   };
 
   const onExitGame = () => {

--- a/src/features/drawing/components/GameControlButtons.tsx
+++ b/src/features/drawing/components/GameControlButtons.tsx
@@ -6,15 +6,17 @@ import { useState } from 'react';
 import Button from '../../../components/Button/Button';
 import Modal from '../../../components/Modal/Modal';
 import useSocketStore from '../../socket/socketStore';
+import { updateGameStatus } from '../../lobby/api/gameRoomsApi';
 
 const GameControlButtons = () => {
   const router = useRouter();
   const { disconnectSocket, socket, roomId } = useSocketStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const onStartGame = () => {
+  const onStartGame = async () => {
     if (socket && roomId) {
       socket.emit('startGame', roomId);
+      await updateGameStatus(roomId, 'playing');
     }
   };
 

--- a/src/features/lobby/api/gameRoomsApi.ts
+++ b/src/features/lobby/api/gameRoomsApi.ts
@@ -83,3 +83,11 @@ export const joinRoom = async (roomId: string): Promise<void> => {
     currentPlayers: increment(1),
   });
 };
+
+export const updateGameStatus = async (
+  roomId: string,
+  status: 'waiting' | 'playing'
+) => {
+  const roomRef = doc(db, 'GameRooms', roomId);
+  await updateDoc(roomRef, { gameStatus: status });
+};


### PR DESCRIPTION
### 📝 관련 이슈
closed #31 

### ✨ 반영 브랜치

<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->

- FROM: `31-feat/game-flow-socket-implementation`
- TO: `master`

### ✅ PR 내용

<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->

- [x] gameState 관리 방법 변경
  > - AS-IS : `initialGameState`라는 로컬 상태를 정의하여 `gameState`를 관리하고, 상태 변경을 위해 `setGameState` 사용
  > - TO-BE : `gameState`를 `socketStore`에서 가져와 사용하고, 상태 업데이트 역시 `socketStore`의 `updateGameState`로 관리
  > - Description : `gameState`를 `socketStore`를 통해 전역적으로 관리하도록 변경
    ``` typescript
    const { socket, roomId, gameState, updateGameState } = useSocketStore();
    ```

- [x] 추가적인 상태 조건부 렌더링 및 레이아웃 일부 수정
  > - AS-IS : QuizState를 선언 후 보여주기 식 상태를 사용
  > - TO-BE : 보여주기 식 상태 삭제
  > - Description : 상태를 `waiting`, `choosing`, `drawing` 3가지로만 구별하여 캔버스 상태 일부 구현(추후 디테일 작업 시 완벽 작업)

- [x] 게임 시작 로직 추가 (onStartGame)
  > - AS-IS : `onStartGame`에서 단순히 콘솔에 'Game started' 메시지를 출력
  > - TO-BE : `onStartGame` 함수가 `socket`과 `roomId`를 이용해 서버에 `startGame` 이벤트를 보냄. 서버에서 게임 상태를 업데이트하고, 클라이언트 측에서는 `updateGameStatus` 함수를 사용해 게임 상태를 'playing'으로 변경(DB gameroom status 업데이트)
  > - Description : 게임 시작에 대한 클라이언트와 서버 간의 동기화를 구현하여 실제 게임이 시작될 수 있도록 처리. 게임 시작과 관련된 데이터 동기화

- [x] 게임 시작 로직 후 choosing 상태 로직 selectedWords와 currentDrawer 초기화
  > - AS-IS : 없음
  > - TO-BE : 서버 측 `startGame` 로직에서 `currentDrawer`를 `host`로 설정하고, `selectedWords`를 단어 리스트 중에서 두 개 선택해 `currentWord` 설정
  > - Description : 단어 선택으로 currentWord가 생성되고, 해당 선택화면은 currentDrawer만 확인 및 선택 가능
현재 currentDrawer만 toolBar 및 그림을 그리도록 구현해야 하지만 그림 데이터를 그릴 수 있는 권한 부여 부분은 구현되어 있지 않음. 쉽게 해결 되지 않아서 디테일 작업 시 함께 작업 예정.

### 🌐 테스트 배포

- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
  > - 테스트 배포 주소: https://jm-doodleplay.netlify.app/game
  > - 테스트 환경 (OS): Windows
  > - 테스트 환경 (Browser): Chrome / Firefox / Edge

### 📌 ETC
우선 적으로 필요한 작업을 먼저 진행 하다 보니 이런 저런 디테일 부분에서 문제가 많습니다.
일단은 필요로 하는 작업을 먼저 리뷰 요청 드리고, 디테일은 다음 이슈에서 완벽하게 잡도록 하겠습니다.
