### PR TITLE
[FEAT] 게임 진행 소켓 작업 #39

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 import ProtectedRoute from '../../components/ProtectedRoute/ProtectedRoute';
 import ChatBox from '../../features/chat/components/ChatBox';
@@ -14,6 +14,21 @@ import useItemStore from '../../features/drawing/store/useItemStore';
 const GamePage = () => {
   const { gameState } = useSocketStore();
   const { resetItemUsageState } = useItemStore();
+  const [isGameStatusModalOpen, setGameStatusModalOpen] = useState(false);
+
+  const onCloseGameStatusModal = () => {
+    setGameStatusModalOpen(false);
+  };
+
+  useEffect(() => {
+    if (isGameStatusModalOpen) {
+      const timer = setTimeout(() => {
+        onCloseGameStatusModal();
+      }, 2000);
+
+      return () => clearTimeout(timer);
+    }
+  }, [isGameStatusModalOpen]);
 
   useEffect(() => {
     resetItemUsageState();
@@ -24,7 +39,7 @@ const GamePage = () => {
       <div className="flex items-center justify-center min-h-dvh overflow-hidden scrollbar-hide">
         <div className="flex w-full max-w-[1240px] gap-[40px]">
           <div className="flex flex-col left w-full gap-y-[20px]">
-            <Drawing />
+            <Drawing isGameStatusModalOpen={isGameStatusModalOpen} />
             <ChatBox />
           </div>
           <div className="flex flex-col right w-full max-w-[420px] gap-y-[20px]">
@@ -37,7 +52,9 @@ const GamePage = () => {
               ) : (
                 <div className="h-[150px]"></div>
               )}
-              <GameControlButtons />
+              <GameControlButtons
+                setGameStatusModalOpen={setGameStatusModalOpen}
+              />
             </div>
           </div>
         </div>

--- a/src/components/GameStatusModal/GameStatusModal.tsx
+++ b/src/components/GameStatusModal/GameStatusModal.tsx
@@ -2,7 +2,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 
 interface GameStatusModalProps {
   isOpen: boolean;
-  errorType: 'full' | 'playing' | null;
+  errorType: 'full' | 'playing' | 'player' | null;
 }
 
 const GameStatusModal: React.FC<GameStatusModalProps> = ({
@@ -47,6 +47,16 @@ const GameStatusModal: React.FC<GameStatusModalProps> = ({
               <h2 className="text-2xl font-bold text-fuschia">Room Full 😢</h2>
               <p className="mt-[10px]">
                 방 정원이 다 찼습니다. 다른 방을 선택해주세요.
+              </p>
+            </>
+          )}
+          {errorType === 'player' && (
+            <>
+              <h2 className="text-2xl font-bold text-fuschia">
+                Not Enough Players 😢
+              </h2>
+              <p className="mt-[10px]">
+                게임을 진행하기 위한 플레이어가 부족합니다.
               </p>
             </>
           )}

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -159,6 +159,7 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
       } else if (selectedTool === 'circle') {
         activateDrawingMode('circle');
       } else if (selectedTool === 'paint') {
+        canvas.isDrawingMode = false; // paint일 때는 그리기 모드를 비활성화
         activateFillMode();
       } else if (selectedTool === 'clear') {
         canvas.clear();

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -758,7 +758,6 @@ const Drawing: React.FC = () => {
               isTimeCut={false}
             />
           )}
-          <div>{gameState?.turn}</div>
         </div>
       </div>
       <Modal

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -12,8 +12,11 @@ import KeywordPlate from '../../../components/KeywordPlate/KeywordPlate';
 import Settings from '../../../components/Settings/Settings';
 import Modal from '../../../components/Modal/Modal';
 import useSocketStore from '../../socket/socketStore';
+import GameStatusModal from '../../../components/GameStatusModal/GameStatusModal';
 
-const Drawing: React.FC = () => {
+const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
+  isGameStatusModalOpen,
+}) => {
   const canvasRef = useRef<fabric.Canvas | null>(null);
   // const [gameState, setGameState] = useState(initialGameState);
   const [comment, setComment] = useState('');
@@ -593,181 +596,184 @@ const Drawing: React.FC = () => {
   ]);
 
   return (
-    <div className="relative rounded-[10px] p-[20px] border-[4px] border-black drop-shadow-drawing bg-white">
-      <h1 className="absolute left-0 right-0 top-0 -translate-y-1/2 m-auto z-[39] max-w-[50%]">
-        <img
-          className="m-auto"
-          src="/images/logo.svg"
-          alt="Logo"
-          draggable={false}
-        />
-      </h1>
-      {/* 정답 단어 KeywordPlate */}
-      {gameState?.currentDrawer === socket?.id &&
-        gameState?.currentWord && // TODO : 그림 그리는 사람만 보여지기
-        gameState?.gameStatus === 'drawing' && (
-          <div className="max-w-[40%] absolute top-[40px] left-0 right-0 m-auto text-center z-[20] opacity-[0.9]">
-            <KeywordPlate title={gameState?.currentWord} isChoosing={false} />
-          </div>
-        )}
+    <>
+      <div className="relative rounded-[10px] p-[20px] border-[4px] border-black drop-shadow-drawing bg-white">
+        <h1 className="absolute left-0 right-0 top-0 -translate-y-1/2 m-auto z-[39] max-w-[50%]">
+          <img
+            className="m-auto"
+            src="/images/logo.svg"
+            alt="Logo"
+            draggable={false}
+          />
+        </h1>
+        {/* 정답 단어 KeywordPlate */}
+        {gameState?.currentDrawer === socket?.id &&
+          gameState?.currentWord && // TODO : 그림 그리는 사람만 보여지기
+          gameState?.gameStatus === 'drawing' && (
+            <div className="max-w-[40%] absolute top-[40px] left-0 right-0 m-auto text-center z-[20] opacity-[0.9]">
+              <KeywordPlate title={gameState?.currentWord} isChoosing={false} />
+            </div>
+          )}
 
-      <div className="flex flex-col gap-y-[20px] max-w-[780px] w-full h-full relative overflow-hidden">
-        <div
-          className={`${
-            canDraw ? 'hidden' : 'flex'
-          } absolute w-full h-full left-0 top-0 z-[11]`}
-        ></div>
-        <canvas
-          id="fabric-canvas"
-          className={`rounded-[10px] absolute w-full h-full left-0 top-0 z-10`} // ${isFlipped ? 'transform scale-y-[-1]' : ''}
-        />
+        <div className="flex flex-col gap-y-[20px] max-w-[780px] w-full h-full relative overflow-hidden">
+          <div
+            className={`${
+              canDraw ? 'hidden' : 'flex'
+            } absolute w-full h-full left-0 top-0 z-[11]`}
+          ></div>
+          <canvas
+            id="fabric-canvas"
+            className={`rounded-[10px] absolute w-full h-full left-0 top-0 z-10`} // ${isFlipped ? 'transform scale-y-[-1]' : ''}
+          />
 
-        {gameState?.items['ToxicCover']?.status && <ToxicEffect />}
-        {gameState?.items['GrowingBomb']?.status && <BombEffect />}
+          {gameState?.items['ToxicCover']?.status && <ToxicEffect />}
+          {gameState?.items['GrowingBomb']?.status && <BombEffect />}
 
-        {gameState?.gameStatus === 'drawing'
-          ? ''
-          : gameState?.turn > 0 &&
-            gameState?.round > 0 && (
-              <div
-                style={{
-                  background: `${
-                    gameState?.gameStatus === 'waiting' && imageLoaded
-                      ? 'linear-gradient(180deg, rgba(34,139,34,1) 0%, rgba(187,230,187,1) 30%, rgba(220,215,96,1) 60%, rgba(255,199,0,1) 100%)'
-                      : ''
-                  }`,
-                }}
-                className="h-full flex flex-col justify-center items-center absolute top-0 left-0 right-0 m-auto z-20"
-              >
-                <img
-                  src={backgroundImage}
-                  onLoad={onImageLoad}
-                  className={`${
-                    comment === '' ? 'max-h-[80%]' : 'max-h-[60%]'
-                  } `}
-                  draggable={false}
-                  loading="lazy"
-                  style={{ visibility: imageLoaded ? 'visible' : 'hidden' }}
-                />
-                {imageLoaded && (
-                  <>
-                    {gameState?.gameStatus === 'waiting' ? (
-                      <NamePlate
-                        title="winner"
-                        score={200}
-                        isDrawingActive
-                        isWinner
-                      />
-                    ) : (
+          {gameState?.gameStatus === 'drawing'
+            ? ''
+            : gameState?.turn > 0 &&
+              gameState?.round > 0 && (
+                <div
+                  style={{
+                    background: `${
+                      gameState?.gameStatus === 'waiting' && imageLoaded
+                        ? 'linear-gradient(180deg, rgba(34,139,34,1) 0%, rgba(187,230,187,1) 30%, rgba(220,215,96,1) 60%, rgba(255,199,0,1) 100%)'
+                        : ''
+                    }`,
+                  }}
+                  className="h-full flex flex-col justify-center items-center absolute top-0 left-0 right-0 m-auto z-20"
+                >
+                  <img
+                    src={backgroundImage}
+                    onLoad={onImageLoad}
+                    className={`${
+                      comment === '' ? 'max-h-[80%]' : 'max-h-[60%]'
+                    } `}
+                    draggable={false}
+                    loading="lazy"
+                    style={{ visibility: imageLoaded ? 'visible' : 'hidden' }}
+                  />
+                  {imageLoaded && (
+                    <>
+                      {gameState?.gameStatus === 'waiting' ? (
+                        <NamePlate
+                          title="winner"
+                          score={200}
+                          isDrawingActive
+                          isWinner
+                        />
+                      ) : (
+                        <p className="text-center font-cherry text-secondary-default text-6xl">
+                          {comment}
+                        </p>
+                      )}
+                    </>
+                  )}
+
+                  {gameState?.gameStatus === 'choosing' &&
+                  gameState?.currentDrawer === socket?.id ? (
+                    <>
                       <p className="text-center font-cherry text-secondary-default text-6xl">
                         {comment}
                       </p>
-                    )}
-                  </>
-                )}
-
-                {gameState?.gameStatus === 'choosing' &&
-                gameState?.currentDrawer === socket?.id ? (
-                  <>
-                    <p className="text-center font-cherry text-secondary-default text-6xl">
-                      {comment}
-                    </p>
-                    <div className="flex space-x-4 mt-4">
-                      {gameState?.selectedWords.map((word, index) => (
-                        <KeywordPlate key={index} title={word} isChoosing />
-                      ))}
-                    </div>
-                  </>
-                ) : (
-                  <></>
-                )}
-              </div>
-            )}
-        <div
-          className={`${
-            isToolbar ? '' : '-translate-x-full -ml-[25px]'
-          } flex justify-between absolute top-0 left-0 z-10 duration-700`}
-        >
-          {gameState?.gameStatus === 'drawing' &&
-            gameState?.currentDrawer === socket?.id && ( // TODO : 그림 그리는 사람만 보여지기
-              <>
-                <Toolbar
-                  selectedTool={selectedTool}
-                  setSelectedTool={setSelectedTool}
-                  selectedColor={selectedColor}
-                  setSelectedColor={setSelectedColor}
-                  selectedSize={selectedSize}
-                  setSelectedSize={setSelectedSize}
-                />
-                <div
-                  className={`${
-                    isToolbar ? 'ml-3' : 'rotate-[900deg] ml-[30px]'
-                  }  absolute w-[30px] h-[30px] left-full top-1/2 -translate-y-1/2  cursor-pointer duration-700`}
-                  onClick={() => setIsToolbar(!isToolbar)}
-                >
-                  <img
-                    src="/images/drawing/toolbarController.svg"
-                    alt="toolbar-controller"
-                    draggable={false}
-                  />
+                      <div className="flex space-x-4 mt-4">
+                        {gameState?.selectedWords.map((word, index) => (
+                          <KeywordPlate key={index} title={word} isChoosing />
+                        ))}
+                      </div>
+                    </>
+                  ) : (
+                    <></>
+                  )}
                 </div>
-              </>
-            )}
-        </div>
-        <div className="absolute top-0 right-0 z-40 max-w-[70px] flex flex-wrap gap-[10px]">
+              )}
           <div
-            className="w-full cursor-pointer"
-            onClick={() => setIsSettingsModalOpen(true)}
+            className={`${
+              isToolbar ? '' : '-translate-x-full -ml-[25px]'
+            } flex justify-between absolute top-0 left-0 z-10 duration-700`}
           >
-            <img
-              src="/images/drawing/settingIcon.png"
-              alt="setting"
-              draggable={false}
-            />
+            {gameState?.gameStatus === 'drawing' &&
+              gameState?.currentDrawer === socket?.id && ( // TODO : 그림 그리는 사람만 보여지기
+                <>
+                  <Toolbar
+                    selectedTool={selectedTool}
+                    setSelectedTool={setSelectedTool}
+                    selectedColor={selectedColor}
+                    setSelectedColor={setSelectedColor}
+                    selectedSize={selectedSize}
+                    setSelectedSize={setSelectedSize}
+                  />
+                  <div
+                    className={`${
+                      isToolbar ? 'ml-3' : 'rotate-[900deg] ml-[30px]'
+                    }  absolute w-[30px] h-[30px] left-full top-1/2 -translate-y-1/2  cursor-pointer duration-700`}
+                    onClick={() => setIsToolbar(!isToolbar)}
+                  >
+                    <img
+                      src="/images/drawing/toolbarController.svg"
+                      alt="toolbar-controller"
+                      draggable={false}
+                    />
+                  </div>
+                </>
+              )}
           </div>
-          {gameState?.gameStatus === 'drawing' && (
-            <ul className="flex flex-col">
-              {gameState &&
-                Object.entries(gameState?.items).map(
-                  ([key, item]) =>
-                    item.status && (
-                      <li key={key}>
-                        <img
-                          src={`/images/drawing/items/${key}.png`}
-                          alt={key}
-                          draggable={false}
-                        />
-                      </li>
-                    )
-                )}
-            </ul>
-          )}
+          <div className="absolute top-0 right-0 z-40 max-w-[70px] flex flex-wrap gap-[10px]">
+            <div
+              className="w-full cursor-pointer"
+              onClick={() => setIsSettingsModalOpen(true)}
+            >
+              <img
+                src="/images/drawing/settingIcon.png"
+                alt="setting"
+                draggable={false}
+              />
+            </div>
+            {gameState?.gameStatus === 'drawing' && (
+              <ul className="flex flex-col">
+                {gameState &&
+                  Object.entries(gameState?.items).map(
+                    ([key, item]) =>
+                      item.status && (
+                        <li key={key}>
+                          <img
+                            src={`/images/drawing/items/${key}.png`}
+                            alt={key}
+                            draggable={false}
+                          />
+                        </li>
+                      )
+                  )}
+              </ul>
+            )}
+          </div>
+          <div className="w-full max-w-[740px] absolute left-0 right-0 bottom-[20px] m-auto z-20">
+            {gameState?.gameStatus === 'drawing' && (
+              <TimeBar
+                duration={90}
+                onComplete={() => console.log('Time Over!')}
+                isTimeCut={gameState?.items['TimeCutter']?.status}
+              />
+            )}
+            {gameState?.gameStatus === 'choosing' && (
+              <TimeBar
+                duration={5}
+                onComplete={() => console.log('Time Over!')}
+                isTimeCut={false}
+              />
+            )}
+          </div>
         </div>
-        <div className="w-full max-w-[740px] absolute left-0 right-0 bottom-[20px] m-auto z-20">
-          {gameState?.gameStatus === 'drawing' && (
-            <TimeBar
-              duration={90}
-              onComplete={() => console.log('Time Over!')}
-              isTimeCut={gameState?.items['TimeCutter']?.status}
-            />
-          )}
-          {gameState?.gameStatus === 'choosing' && (
-            <TimeBar
-              duration={5}
-              onComplete={() => console.log('Time Over!')}
-              isTimeCut={false}
-            />
-          )}
-        </div>
+        <Modal
+          isOpen={isSettingsModalOpen}
+          title="Setting"
+          onClose={() => setIsSettingsModalOpen(false)}
+        >
+          <Settings />
+        </Modal>
       </div>
-      <Modal
-        isOpen={isSettingsModalOpen}
-        title="Setting"
-        onClose={() => setIsSettingsModalOpen(false)}
-      >
-        <Settings />
-      </Modal>
-    </div>
+      <GameStatusModal isOpen={isGameStatusModalOpen} errorType={'player'} />
+    </>
   );
 };
 

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -28,6 +28,7 @@ const Drawing: React.FC = () => {
 
   const [imageLoaded, setImageLoaded] = useState(false); // 이미지 로딩 상태 추가
   const [backgroundImage, setBackgroundImage] = useState(''); // 배경 이미지 경로 상태
+  const [isTimeOver, setIsTimeOver] = useState(false); // TimeOver 상태 추가
 
   // TODO: 61번쨰 줄의 gameState 개별관리 코드 없어지면 gameState 별칭 지우기
   const { socket, roomId, gameState, updateGameState } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
@@ -323,25 +324,19 @@ const Drawing: React.FC = () => {
   // TODO : case가 status인데, 추후 조건 변경 status = 'waiting', 'choosing', 'drawing' 3가지로 구분
   const updateBackgroundImage = () => {
     let imgPath = '';
-    const currentTime = Date.now();
 
     switch (gameState?.gameStatus) {
       case 'waiting':
         imgPath = '/images/drawing/waiting.png';
         break;
+      case 'timeOver':
+        imgPath = '/images/drawing/timeOver.png';
+        break;
       case 'choosing':
-        if (
-          gameState?.selectionDeadline &&
-          currentTime >= gameState.selectionDeadline &&
-          !gameState.isWordSelected
-        ) {
-          imgPath = '/images/drawing/timeOver.png';
-        } else {
-          imgPath =
-            gameState?.currentDrawer !== socket?.id
-              ? '/images/drawing/breakTime.png'
-              : '';
-        }
+        imgPath =
+          gameState?.currentDrawer !== socket?.id
+            ? '/images/drawing/breakTime.png'
+            : '';
         break;
       default:
         imgPath = '';
@@ -352,7 +347,7 @@ const Drawing: React.FC = () => {
 
   useEffect(() => {
     updateBackgroundImage();
-  }, [gameState]);
+  }, [gameState?.gameStatus]);
 
   // 게임 상태에 따라 화면에 보여줄 메시지 업데이트
   useEffect(() => {
@@ -361,8 +356,10 @@ const Drawing: React.FC = () => {
       gameState?.currentDrawer === socket?.id
     ) {
       setComment('Choose a word');
-    } else {
+    } else if (gameState?.gameStatus === 'choosing') {
       setComment('Break Time');
+    } else if (gameState?.gameStatus === 'timeOver') {
+      setComment("Time's up");
     }
   }, [gameState]);
 
@@ -761,7 +758,7 @@ const Drawing: React.FC = () => {
               isTimeCut={false}
             />
           )}
-          <div>{gameState?.gameStatus}</div>
+          <div>{gameState?.turn}</div>
         </div>
       </div>
       <Modal

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -31,6 +31,10 @@ const Drawing: React.FC = () => {
 
   // TODO: 61번쨰 줄의 gameState 개별관리 코드 없어지면 gameState 별칭 지우기
   const { socket, roomId, gameState, updateGameState } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
+  // 현재 사용자가 그림을 그릴 수 있는 조건
+  const canDraw =
+    gameState?.currentDrawer === socket?.id &&
+    gameState?.gameStatus === 'drawing';
 
   // 캔버스를 초기화하고, 선택된 도구에 맞게 브러시 설정
   useEffect(() => {

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -623,7 +623,7 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
         </h1>
         {/* 정답 단어 KeywordPlate */}
         {gameState?.currentDrawer === socket?.id &&
-          gameState?.currentWord && // TODO : 그림 그리는 사람만 보여지기
+          gameState?.currentWord &&
           gameState?.gameStatus === 'drawing' && (
             <div className="max-w-[40%] absolute top-[40px] left-0 right-0 m-auto text-center z-[20] opacity-[0.9]">
               <KeywordPlate title={gameState?.currentWord} isChoosing={false} />
@@ -708,7 +708,7 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
             } flex justify-between absolute top-0 left-0 z-10 duration-700`}
           >
             {gameState?.gameStatus === 'drawing' &&
-              gameState?.currentDrawer === socket?.id && ( // TODO : 그림 그리는 사람만 보여지기
+              gameState?.currentDrawer === socket?.id && (
                 <>
                   <Toolbar
                     selectedTool={selectedTool}

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -323,17 +323,26 @@ const Drawing: React.FC = () => {
   // TODO : case가 status인데, 추후 조건 변경 status = 'waiting', 'choosing', 'drawing' 3가지로 구분
   const updateBackgroundImage = () => {
     let imgPath = '';
+    const currentTime = Date.now();
+
     switch (gameState?.gameStatus) {
       case 'waiting':
         imgPath = '/images/drawing/waiting.png';
         break;
       case 'choosing':
-        imgPath =
-          gameState?.currentDrawer !== socket?.id &&
-          '/images/drawing/breakTime.png';
+        if (
+          gameState?.selectionDeadline &&
+          currentTime >= gameState.selectionDeadline &&
+          !gameState.isWordSelected
+        ) {
+          imgPath = '/images/drawing/timeOver.png';
+        } else {
+          imgPath =
+            gameState?.currentDrawer !== socket?.id
+              ? '/images/drawing/breakTime.png'
+              : '';
+        }
         break;
-      case 'drawing':
-        imgPath = '/images/drawing/breakTime.png';
       default:
         imgPath = '';
     }
@@ -752,6 +761,7 @@ const Drawing: React.FC = () => {
               isTimeCut={false}
             />
           )}
+          <div>{gameState?.gameStatus}</div>
         </div>
       </div>
       <Modal

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -28,7 +28,6 @@ const Drawing: React.FC = () => {
 
   const [imageLoaded, setImageLoaded] = useState(false); // 이미지 로딩 상태 추가
   const [backgroundImage, setBackgroundImage] = useState(''); // 배경 이미지 경로 상태
-  const [isTimeOver, setIsTimeOver] = useState(false); // TimeOver 상태 추가
 
   // TODO: 61번쨰 줄의 gameState 개별관리 코드 없어지면 gameState 별칭 지우기
   const { socket, roomId, gameState, updateGameState } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
@@ -437,9 +436,7 @@ const Drawing: React.FC = () => {
       const pointer = canvas.getPointer(event.e);
       isDrawing = true;
 
-      if (selectedTool === 'clear') {
-        setSelectedTool('clear'); // clear 후 자동으로 pencil 도구로 변경
-      } else if (selectedTool === 'pencil' || selectedTool === 'eraser') {
+      if (selectedTool === 'pencil' || selectedTool === 'eraser') {
         sendDrawingData('start', pointer.x, pointer.y, selectedTool);
       }
     });
@@ -628,61 +625,64 @@ const Drawing: React.FC = () => {
         {gameState?.items['ToxicCover']?.status && <ToxicEffect />}
         {gameState?.items['GrowingBomb']?.status && <BombEffect />}
 
-        {gameState?.gameStatus === 'drawing' ? (
-          ''
-        ) : (
-          <div
-            style={{
-              background: `${
-                gameState?.gameStatus === 'waiting' && imageLoaded
-                  ? 'linear-gradient(180deg, rgba(34,139,34,1) 0%, rgba(187,230,187,1) 30%, rgba(220,215,96,1) 60%, rgba(255,199,0,1) 100%)'
-                  : ''
-              }`,
-            }}
-            className="h-full flex flex-col justify-center items-center absolute top-0 left-0 right-0 m-auto z-20"
-          >
-            <img
-              src={backgroundImage}
-              onLoad={onImageLoad}
-              className={`${comment === '' ? 'max-h-[80%]' : 'max-h-[60%]'} `}
-              draggable={false}
-              loading="lazy"
-              style={{ visibility: imageLoaded ? 'visible' : 'hidden' }}
-            />
-            {imageLoaded && (
-              <>
-                {gameState?.gameStatus === 'waiting' ? (
-                  <NamePlate
-                    title="winner"
-                    score={200}
-                    isDrawingActive
-                    isWinner
-                  />
-                ) : (
-                  <p className="text-center font-cherry text-secondary-default text-6xl">
-                    {comment}
-                  </p>
+        {gameState?.gameStatus === 'drawing'
+          ? ''
+          : gameState?.turn > 0 &&
+            gameState?.round > 0 && (
+              <div
+                style={{
+                  background: `${
+                    gameState?.gameStatus === 'waiting' && imageLoaded
+                      ? 'linear-gradient(180deg, rgba(34,139,34,1) 0%, rgba(187,230,187,1) 30%, rgba(220,215,96,1) 60%, rgba(255,199,0,1) 100%)'
+                      : ''
+                  }`,
+                }}
+                className="h-full flex flex-col justify-center items-center absolute top-0 left-0 right-0 m-auto z-20"
+              >
+                <img
+                  src={backgroundImage}
+                  onLoad={onImageLoad}
+                  className={`${
+                    comment === '' ? 'max-h-[80%]' : 'max-h-[60%]'
+                  } `}
+                  draggable={false}
+                  loading="lazy"
+                  style={{ visibility: imageLoaded ? 'visible' : 'hidden' }}
+                />
+                {imageLoaded && (
+                  <>
+                    {gameState?.gameStatus === 'waiting' ? (
+                      <NamePlate
+                        title="winner"
+                        score={200}
+                        isDrawingActive
+                        isWinner
+                      />
+                    ) : (
+                      <p className="text-center font-cherry text-secondary-default text-6xl">
+                        {comment}
+                      </p>
+                    )}
+                  </>
                 )}
-              </>
-            )}
 
-            {gameState?.gameStatus === 'choosing' &&
-            gameState?.currentDrawer === socket?.id ? (
-              <>
-                <p className="text-center font-cherry text-secondary-default text-6xl">
-                  {comment}
-                </p>
-                <div className="flex space-x-4 mt-4">
-                  {gameState?.selectedWords.map((word, index) => (
-                    <KeywordPlate key={index} title={word} isChoosing />
-                  ))}
-                </div>
-              </>
-            ) : (
-              <></>
+                {gameState?.gameStatus === 'choosing' &&
+                gameState?.currentDrawer === socket?.id ? (
+                  <>
+                    <p className="text-center font-cherry text-secondary-default text-6xl">
+                      {comment}
+                    </p>
+                    <div className="flex space-x-4 mt-4">
+                      {gameState?.selectedWords.map((word, index) => (
+                        <KeywordPlate key={index} title={word} isChoosing />
+                      ))}
+                    </div>
+                  </>
+                ) : (
+                  <></>
+                )}
+              </div>
             )}
-          </div>
-        )}
         <div
           className={`${
             isToolbar ? '' : '-translate-x-full -ml-[25px]'

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -379,6 +379,23 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
     };
   }, [updateGameState]);
 
+  // 소켓을 통해 서버에서 clearCanvas 이벤트를 수신하고 캔버스를 초기화
+  useEffect(() => {
+    if (socket) {
+      socket.on('clearCanvas', () => {
+        if (canvasRef.current) {
+          canvasRef.current.clear(); // 캔버스 초기화
+        }
+      });
+    }
+
+    return () => {
+      if (socket) {
+        socket.off('clearCanvas');
+      }
+    };
+  }, [socket]);
+
   useEffect(() => {
     if (gameState?.activeItem) {
       const { activeItem } = gameState;

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -18,7 +18,6 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   isGameStatusModalOpen,
 }) => {
   const canvasRef = useRef<fabric.Canvas | null>(null);
-  // const [gameState, setGameState] = useState(initialGameState);
   const [comment, setComment] = useState('');
   const [selectedTool, setSelectedTool] = useState<
     'pencil' | 'eraser' | 'square' | 'paint' | 'circle' | 'clear'
@@ -32,8 +31,7 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   const [imageLoaded, setImageLoaded] = useState(false); // 이미지 로딩 상태 추가
   const [backgroundImage, setBackgroundImage] = useState(''); // 배경 이미지 경로 상태
 
-  // TODO: 61번쨰 줄의 gameState 개별관리 코드 없어지면 gameState 별칭 지우기
-  const { socket, roomId, gameState, updateGameState } = useSocketStore(); // 소켓 스토어에서 소켓과 roomId를 가져옴
+  const { socket, roomId, gameState, updateGameState } = useSocketStore();
   // 현재 사용자가 그림을 그릴 수 있는 조건
   const canDraw =
     gameState?.currentDrawer === socket?.id &&
@@ -324,7 +322,6 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   }, []);
 
   // 게임 상태에 따른 배경 이미지 업데이트
-  // TODO : case가 status인데, 추후 조건 변경 status = 'waiting', 'choosing', 'drawing' 3가지로 구분
   const updateBackgroundImage = () => {
     let imgPath = '';
 

--- a/src/features/drawing/components/GameControlButtons.tsx
+++ b/src/features/drawing/components/GameControlButtons.tsx
@@ -6,7 +6,6 @@ import { useState } from 'react';
 import Button from '../../../components/Button/Button';
 import Modal from '../../../components/Modal/Modal';
 import useSocketStore from '../../socket/socketStore';
-import { updateGameStatus } from '../../lobby/api/gameRoomsApi';
 
 const GameControlButtons = () => {
   const router = useRouter();
@@ -17,7 +16,6 @@ const GameControlButtons = () => {
   const onStartGame = async () => {
     if (socket && roomId) {
       socket.emit('startGame', roomId);
-      await updateGameStatus(roomId, 'playing');
       setIsHiddenButton(true);
     }
   };

--- a/src/features/drawing/components/GameControlButtons.tsx
+++ b/src/features/drawing/components/GameControlButtons.tsx
@@ -10,13 +10,15 @@ import { updateGameStatus } from '../../lobby/api/gameRoomsApi';
 
 const GameControlButtons = () => {
   const router = useRouter();
-  const { disconnectSocket, socket, roomId } = useSocketStore();
+  const { gameState, disconnectSocket, socket, roomId } = useSocketStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isHiddenButton, setIsHiddenButton] = useState(false);
 
   const onStartGame = async () => {
     if (socket && roomId) {
       socket.emit('startGame', roomId);
       await updateGameStatus(roomId, 'playing');
+      setIsHiddenButton(true);
     }
   };
 
@@ -34,16 +36,19 @@ const GameControlButtons = () => {
     setIsModalOpen(false); // 모달을 닫습니다.
   };
 
-  //TODO: 방장(host)만 게임이 진행되기 전에만 start 버튼 보이도록
-
   return (
     <div className="w-full flex gap-x-[30px]">
-      <Button
-        text="START"
-        color="primary"
-        onClick={onStartGame}
-        className="h-[70px]"
-      />
+      {gameState?.host === socket?.id ? (
+        <Button
+          text="START"
+          color="primary"
+          onClick={onStartGame}
+          className={`h-[70px] ${isHiddenButton ? 'hidden' : ''}`}
+        />
+      ) : (
+        ''
+      )}
+
       <Button
         text="EXIT"
         color="secondary"

--- a/src/features/drawing/components/GameControlButtons.tsx
+++ b/src/features/drawing/components/GameControlButtons.tsx
@@ -11,15 +11,12 @@ const GameControlButtons = ({ setGameStatusModalOpen }) => {
   const router = useRouter();
   const { gameState, disconnectSocket, socket, roomId } = useSocketStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isHiddenButton, setIsHiddenButton] = useState(false);
 
   const onStartGame = () => {
     if (gameState?.order.length < 3) {
       setGameStatusModalOpen(true);
-      setIsHiddenButton(false);
     } else if (socket && roomId) {
       socket.emit('startGame', roomId);
-      setIsHiddenButton(true);
     }
   };
 
@@ -37,23 +34,17 @@ const GameControlButtons = ({ setGameStatusModalOpen }) => {
     setIsModalOpen(false); // 모달을 닫습니다.
   };
 
-  // 게임이 waiting 상태로 돌아오면 버튼을 다시 보여줌
-  useEffect(() => {
-    if (gameState?.gameStatus === 'waiting') {
-      setIsHiddenButton(false);
-    }
-  }, [gameState?.gameStatus]);
-
   return (
     <div className="w-full flex gap-x-[30px]">
-      {gameState?.host === socket?.id && !isHiddenButton && (
-        <Button
-          text="START"
-          color="primary"
-          onClick={onStartGame}
-          className="h-[70px]"
-        />
-      )}
+      {gameState?.host === socket?.id &&
+        gameState?.gameStatus === 'waiting' && (
+          <Button
+            text="START"
+            color="primary"
+            onClick={onStartGame}
+            className="h-[70px]"
+          />
+        )}
       <Button
         text="EXIT"
         color="secondary"

--- a/src/features/drawing/components/GameControlButtons.tsx
+++ b/src/features/drawing/components/GameControlButtons.tsx
@@ -1,20 +1,23 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import Button from '../../../components/Button/Button';
 import Modal from '../../../components/Modal/Modal';
 import useSocketStore from '../../socket/socketStore';
 
-const GameControlButtons = () => {
+const GameControlButtons = ({ setGameStatusModalOpen }) => {
   const router = useRouter();
   const { gameState, disconnectSocket, socket, roomId } = useSocketStore();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isHiddenButton, setIsHiddenButton] = useState(false);
 
-  const onStartGame = async () => {
-    if (socket && roomId) {
+  const onStartGame = () => {
+    if (gameState?.order.length < 3) {
+      setGameStatusModalOpen(true);
+      setIsHiddenButton(false);
+    } else if (socket && roomId) {
       socket.emit('startGame', roomId);
       setIsHiddenButton(true);
     }
@@ -34,19 +37,23 @@ const GameControlButtons = () => {
     setIsModalOpen(false); // 모달을 닫습니다.
   };
 
+  // 게임이 waiting 상태로 돌아오면 버튼을 다시 보여줌
+  useEffect(() => {
+    if (gameState?.gameStatus === 'waiting') {
+      setIsHiddenButton(false);
+    }
+  }, [gameState?.gameStatus]);
+
   return (
     <div className="w-full flex gap-x-[30px]">
-      {gameState?.host === socket?.id ? (
+      {gameState?.host === socket?.id && !isHiddenButton && (
         <Button
           text="START"
           color="primary"
           onClick={onStartGame}
-          className={`h-[70px] ${isHiddenButton ? 'hidden' : ''}`}
+          className="h-[70px]"
         />
-      ) : (
-        ''
       )}
-
       <Button
         text="EXIT"
         color="secondary"

--- a/src/features/lobby/api/gameRoomsApi.ts
+++ b/src/features/lobby/api/gameRoomsApi.ts
@@ -83,11 +83,3 @@ export const joinRoom = async (roomId: string): Promise<void> => {
     currentPlayers: increment(1),
   });
 };
-
-export const updateGameStatus = async (
-  roomId: string,
-  status: 'waiting' | 'playing'
-) => {
-  const roomRef = doc(db, 'GameRooms', roomId);
-  await updateDoc(roomRef, { gameStatus: status });
-};

--- a/src/features/lobby/components/RoomSearchSection.tsx
+++ b/src/features/lobby/components/RoomSearchSection.tsx
@@ -8,7 +8,7 @@ import Button from '../../../components/Button/Button';
 import Modal from '../../../components/Modal/Modal';
 import RefreshButton from './RefreshButton';
 import SearchBar from './SearchBar';
-import GameStatusModal from './GameStatusModal';
+import GameStatusModal from '../../../components/GameStatusModal/GameStatusModal';
 import RoomCard from './RoomCard';
 import { Room, getRoomById, getRooms, joinRoom } from '../api/gameRoomsApi';
 import useUserInfoStore from '../../profile/store/userInfoStore';

--- a/src/features/socket/socketStore.ts
+++ b/src/features/socket/socketStore.ts
@@ -11,12 +11,13 @@ interface Participant {
 
 interface GameState {
   host: string;
-  gameStatus: 'waiting' | 'choosing' | 'drawing';
+  gameStatus: 'waiting' | 'choosing' | 'drawing' | 'timeOver';
   currentDrawer: string | null;
   currentWord: string | null;
   totalWords: string[];
   selectedWords: string[];
   isWordSelected: boolean;
+  topic: string;
   selectionDeadline: number | null;
   maxRound: number;
   round: number;


### PR DESCRIPTION
### 📝 관련 이슈
closed #39

### ✨ 반영 브랜치

<!-- 어떤 브랜치에서 어떤 브랜치로 merge하는지 적어주세요 -->

- FROM: `39-feat/game-flow-socket`
- TO: `master`

### ✅ PR 내용

<!-- 기능마다 아래 템플릿으로 PR에 대한 설명을 적어주세요 (기능별 AS-IS, TO-BE, 변경이유 등) -->

- [x] 게임 시작 조건 및 상태 모달 확인 추가
  > - AS-IS : `onStartGame` 함수는 `socket`과 `roomId`가 존재하면 바로 `startGame` 이벤트를 발생시키고 `updateGameStatus`를 호출해 게임 상태를 'playing'으로 변경
  > - TO-BE : 게임 시작 전, `gameState?.order.length`가 3 미만일 경우 게임 상태 모달을 `setGameStatusModalOpen`으로 호출하여 게임 시작 제한. 플레이어 수가 조건을 만족할 경우에만 `socket.emit('startGame', roomId)` 이벤트가 발생
  > - Description : 플레이어 수가 3명 이상일 때만 게임이 시작될 수 있도록 조건을 추가하여 게임 시작 가능 여부를 확인하는 모달 기능을 보완했습니다. 사용자 경험과 게임 규칙을 명확히 제어할 수 있습니다.

- [x] 게임 진행 중 툴바와 그리기 권한 관리
  > - AS-IS : 그리기 권한을 개별적으로 제어하지 않고, 게임 상태와 `currentDrawer` 확인 로직이 일부에서만 적용
  > - TO-BE : `canDraw` 상태를 추가하여 `gameState?.currentDrawer === socket?.id && gameState?.gameStatus === 'drawing'` 조건이 충족될 때만 `canvas`에서 그림을 그릴 수 있도록 제어
  > - Description : `canDraw` 상태로 현재 사용자가 그림을 그릴 수 있는지 여부를 관리하여, 게임 중 출제자만 그릴 수 있도록 했습니다. 클라이언트의 그리기 권한을 명확히 분리하고, 다른 참여자에게는 그리기 툴바가 비활성화됩니다.

- [x] 게임 상태에 따른 배경 이미지 업데이트 로직 추가
  > - AS-IS : 배경 이미지를 업데이트하는 코드가 단순히 `gameState?.gameStatus`를 바탕으로 작동
  > - TO-BE : `gameState?.gameStatus`가 `choosing`일 때 출제자가 아닌 경우에는 `breakTime` 이미지를 표시하도록 조건을 추가하였고, `timeOver `상태에서는 `timeOver` 이미지를 설정하도록 보완
  > - Description : 게임 진행 상태에 따라 다양한 배경 이미지가 적용될 수 있도록 세분화하여, 게임 진행 상황을 직관적으로 확인할 수 있도록 개선했습니다.

- [x] 게임 상태 DB업데이트 수정
  > - AS-IS : 클라이언트 내에서 DB업데이트 작업
  > - TO-BE : 서버 내에서 DB 업데이트 로직 추가
  > - Description : 기존 gameRoomApi에서 진행하던 DB 업데이트를 서버 쪽으로 이동 구현

### 🌐 테스트 배포

- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
  > - 테스트 배포 주소: https://jm-doodleplay.netlify.app/game
  > - 테스트 환경 (OS): Windows
  > - 테스트 환경 (Browser): Chrome / Firefox / Edge

### 📌 ETC
기능 위주의 PR이라 뷰 단에서는 차이를 많이 볼 수는 없고, 기능은 Server merge 되지 않아서 확인은 어렵습니다. 참고 바랍니다. 코드 위주의 리뷰 부탁드리며, 중요 내용은 Server 쪽 코드에서 확인 바랍니다!
