### PR TITLE
[FEAT] 아이템 사용 소켓 추가 작업 #41

### DIFF
--- a/src/features/chat/components/ChatBox.tsx
+++ b/src/features/chat/components/ChatBox.tsx
@@ -17,7 +17,7 @@ interface ChatMessage {
 const ChatBox: React.FC = () => {
   const router = useRouter();
   const { nickname } = useUserInfoStore();
-  const { socket, roomId, disconnectSocket } = useSocketStore();
+  const { socket, roomId, disconnectSocket, gameState } = useSocketStore();
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const chatInputRef = useRef<HTMLInputElement>(null);
   const [inputValue, setInputValue] = useState('');
@@ -63,6 +63,10 @@ const ChatBox: React.FC = () => {
   useEffect(() => {
     if (socket) {
       socket.on('newMessage', (message: ChatMessage) => {
+        if (gameState?.items.phantomReverse.status) {
+          message.message = message.message.split('').reverse().join('');
+        }
+
         setMessages(prevMessages => [...prevMessages, message]);
       });
 
@@ -96,7 +100,7 @@ const ChatBox: React.FC = () => {
         socket.off('userLeft');
       }
     };
-  }, [socket]);
+  }, [socket, gameState]);
 
   const handleDisconnect = () => {
     disconnectSocket();

--- a/src/features/chat/components/ChatBox.tsx
+++ b/src/features/chat/components/ChatBox.tsx
@@ -30,6 +30,10 @@ const ChatBox: React.FC = () => {
         message: inputValue,
       };
 
+      if (gameState?.items.phantomReverse.status) {
+        newMessage.message = newMessage.message.split('').reverse().join('');
+      }
+
       socket.emit('sendMessage', roomId, newMessage);
 
       setInputValue('');
@@ -42,6 +46,10 @@ const ChatBox: React.FC = () => {
         nickname,
         message: inputValue,
       };
+
+      if (gameState?.items.phantomReverse.status) {
+        newMessage.message = newMessage.message.split('').reverse().join('');
+      }
 
       socket.emit('sendMessage', roomId, newMessage);
 
@@ -63,10 +71,6 @@ const ChatBox: React.FC = () => {
   useEffect(() => {
     if (socket) {
       socket.on('newMessage', (message: ChatMessage) => {
-        if (gameState?.items.phantomReverse.status) {
-          message.message = message.message.split('').reverse().join('');
-        }
-
         setMessages(prevMessages => [...prevMessages, message]);
       });
 

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -388,7 +388,7 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
     if (gameState?.activeItem) {
       const { activeItem } = gameState;
 
-      if (activeItem === 'LaundryFlip') {
+      if (activeItem === 'laundryFlip') {
         if (canvasRef.current) {
           const canvas = canvasRef.current;
           canvas.getObjects().forEach(obj => {
@@ -629,8 +629,8 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
             className={`rounded-[10px] absolute w-full h-full left-0 top-0 z-10`} // ${isFlipped ? 'transform scale-y-[-1]' : ''}
           />
 
-          {gameState?.items['ToxicCover']?.status && <ToxicEffect />}
-          {gameState?.items['GrowingBomb']?.status && <BombEffect />}
+          {gameState?.items['toxicCover']?.status && <ToxicEffect />}
+          {gameState?.items['growingBomb']?.status && <BombEffect />}
 
           {gameState?.gameStatus === 'drawing'
             ? ''
@@ -755,7 +755,7 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
               <TimeBar
                 duration={90}
                 onComplete={() => console.log('Time Over!')}
-                isTimeCut={gameState?.items['TimeCutter']?.status}
+                isTimeCut={gameState?.items['timeCutter']?.status}
               />
             )}
             {gameState?.gameStatus === 'choosing' && (

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -31,7 +31,7 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   const [imageLoaded, setImageLoaded] = useState(false); // 이미지 로딩 상태 추가
   const [backgroundImage, setBackgroundImage] = useState(''); // 배경 이미지 경로 상태
 
-  const { socket, roomId, gameState, updateGameState } = useSocketStore();
+  const { socket, roomId, gameState } = useSocketStore();
   // 현재 사용자가 그림을 그릴 수 있는 조건
   const canDraw =
     gameState?.currentDrawer === socket?.id &&
@@ -366,18 +366,6 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   const onImageLoad = () => {
     setImageLoaded(true);
   };
-
-  useEffect(() => {
-    if (socket) {
-      socket.on('itemUsedUpdate', updatedGameState => {
-        updateGameState(updatedGameState);
-      });
-    }
-
-    return () => {
-      if (socket) socket.off('itemUsedUpdate');
-    };
-  }, [updateGameState]);
 
   // 소켓을 통해 서버에서 clearCanvas 이벤트를 수신하고 캔버스를 초기화
   useEffect(() => {

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -13,6 +13,7 @@ import Settings from '../../../components/Settings/Settings';
 import Modal from '../../../components/Modal/Modal';
 import useSocketStore from '../../socket/socketStore';
 import GameStatusModal from '../../../components/GameStatusModal/GameStatusModal';
+import useItemStore from '../store/useItemStore';
 
 const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   isGameStatusModalOpen,
@@ -35,6 +36,8 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   );
 
   const { socket, roomId, gameState } = useSocketStore();
+  const { resetItemUsageState } = useItemStore();
+
   // 현재 사용자가 그림을 그릴 수 있는 조건
   const canDraw =
     gameState?.currentDrawer === socket?.id &&
@@ -349,6 +352,8 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   };
 
   useEffect(() => {
+    if (gameState?.gameStatus === 'waiting') resetItemUsageState();
+
     updateBackgroundImage();
   }, [gameState?.gameStatus]);
 
@@ -766,15 +771,13 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
           <div className="w-full max-w-[740px] absolute left-0 right-0 bottom-[20px] m-auto z-20">
             {gameState?.gameStatus === 'drawing' && (
               <TimeBar
-                duration={90}
-                onComplete={() => console.log('Time Over!')}
+                deadline={gameState?.turnDeadline}
                 isTimeCut={gameState?.items['timeCutter']?.status}
               />
             )}
             {gameState?.gameStatus === 'choosing' && (
               <TimeBar
-                duration={5}
-                onComplete={() => console.log('Time Over!')}
+                deadline={gameState?.selectionDeadline}
                 isTimeCut={false}
               />
             )}

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -385,20 +385,16 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
   }, [socket]);
 
   useEffect(() => {
-    if (gameState?.activeItem) {
-      const { activeItem } = gameState;
-
-      if (activeItem === 'laundryFlip') {
-        if (canvasRef.current) {
-          const canvas = canvasRef.current;
-          canvas.getObjects().forEach(obj => {
-            obj.set('flipY', !obj.flipY); // 현재 상태 반전
-          });
-          canvas.renderAll();
-        }
+    if (gameState?.items.laundryFlip.status) {
+      if (canvasRef.current) {
+        const canvas = canvasRef.current;
+        canvas.getObjects().forEach(obj => {
+          obj.set('flipY', !obj.flipY); // 현재 상태 반전
+        });
+        canvas.renderAll();
       }
     }
-  }, [gameState?.activeItem]);
+  }, [gameState?.items.laundryFlip.status]);
 
   // socket으로 clear 전송
   useEffect(() => {

--- a/src/features/drawing/components/Drawing.tsx
+++ b/src/features/drawing/components/Drawing.tsx
@@ -5,7 +5,7 @@ import * as fabric from 'fabric';
 
 import TimeBar from './TimeBar';
 import Toolbar from './Toolbar';
-import ToxicEffect from './ToxicEffect';
+import ToxicEffect, { Position } from './ToxicEffect';
 import BombEffect from './BombEffect';
 import NamePlate from '../../../components/NamePlate/NamePlate';
 import KeywordPlate from '../../../components/KeywordPlate/KeywordPlate';
@@ -30,6 +30,9 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
 
   const [imageLoaded, setImageLoaded] = useState(false); // 이미지 로딩 상태 추가
   const [backgroundImage, setBackgroundImage] = useState(''); // 배경 이미지 경로 상태
+  const [toxicEffectPositions, setToxicEffectPositions] = useState<Position[]>(
+    []
+  );
 
   const { socket, roomId, gameState } = useSocketStore();
   // 현재 사용자가 그림을 그릴 수 있는 조건
@@ -396,6 +399,18 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
     }
   }, [gameState?.items.laundryFlip.status]);
 
+  useEffect(() => {
+    if (socket) {
+      socket.on('toxicEffectPositions', (positions: Position[]) => {
+        setToxicEffectPositions(positions);
+      });
+
+      return () => {
+        socket.off('toxicEffectPositions');
+      };
+    }
+  }, [socket]);
+
   // socket으로 clear 전송
   useEffect(() => {
     if (selectedTool === 'clear') {
@@ -625,7 +640,9 @@ const Drawing: React.FC<{ isGameStatusModalOpen: boolean }> = ({
             className={`rounded-[10px] absolute w-full h-full left-0 top-0 z-10`} // ${isFlipped ? 'transform scale-y-[-1]' : ''}
           />
 
-          {gameState?.items['toxicCover']?.status && <ToxicEffect />}
+          {gameState?.items['toxicCover']?.status && (
+            <ToxicEffect toxicEffectPositions={toxicEffectPositions} />
+          )}
           {gameState?.items['growingBomb']?.status && <BombEffect />}
 
           {gameState?.gameStatus === 'drawing'

--- a/src/features/drawing/components/GameControlButtons.tsx
+++ b/src/features/drawing/components/GameControlButtons.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import Button from '../../../components/Button/Button';
 import Modal from '../../../components/Modal/Modal';

--- a/src/features/drawing/components/ItemBox.tsx
+++ b/src/features/drawing/components/ItemBox.tsx
@@ -39,6 +39,7 @@ const ItemBox: React.FC = () => {
 
   const onHandleItemClick = (itemId: string) => {
     if (
+      gameState.gameStatus === 'drawing' &&
       !itemUsageState[itemId as keyof typeof itemUsageState] &&
       !gameState.items[itemId as keyof typeof itemUsageState].status &&
       !isAnyItemUsedThisRound
@@ -70,16 +71,19 @@ const ItemBox: React.FC = () => {
           <div
             key={item.id}
             className="relative max-w-[70px] max-h-[70px] bg-white border-[3px] border-black rounded-[5px] z-30 cursor-pointer"
-            onMouseEnter={() => setHoveredItem(item.id)}
-            onMouseLeave={() => setHoveredItem(null)}
-            onClick={() => onHandleItemClick(item.id)}
           >
-            <img
-              src={item.image}
-              alt={item.id}
-              className="w-full h-full object-contain"
-              draggable={false}
-            />
+            <div
+              onMouseEnter={() => setHoveredItem(item.id)}
+              onMouseLeave={() => setHoveredItem(null)}
+              onClick={() => onHandleItemClick(item.id)}
+            >
+              <img
+                src={item.image}
+                alt={item.id}
+                className="w-full h-full object-contain"
+                draggable={false}
+              />
+            </div>
 
             {(gameState.items[item.id as keyof typeof itemUsageState].status ||
               isAnyItemUsedThisRound) && (

--- a/src/features/drawing/components/ItemBox.tsx
+++ b/src/features/drawing/components/ItemBox.tsx
@@ -6,27 +6,27 @@ import useSocketStore from '../../socket/socketStore';
 
 const items = [
   {
-    id: 'ToxicCover',
+    id: 'toxicCover',
     image: '/images/drawing/items/toxicCover.png',
     description: '군데군데 독극물을 뿌린다.',
   },
   {
-    id: 'GrowingBomb',
+    id: 'growingBomb',
     image: '/images/drawing/items/growingBomb.png',
     description: '5초간 폭발이 발생한다.',
   },
   {
-    id: 'PhantomReverse',
+    id: 'phantomReverse',
     image: '/images/drawing/items/phantomReverse.png',
     description: '글자를 거꾸로 입력한다.',
   },
   {
-    id: 'LaundryFlip',
+    id: 'laundryFlip',
     image: '/images/drawing/items/laundryFlip.png',
     description: '그림을 뒤집는다.',
   },
   {
-    id: 'TimeCutter',
+    id: 'timeCutter',
     image: '/images/drawing/items/timeCutter.png',
     description: '시간의 반을 먹어치운다.',
   },

--- a/src/features/drawing/components/ItemBox.tsx
+++ b/src/features/drawing/components/ItemBox.tsx
@@ -49,7 +49,6 @@ const ItemBox: React.FC = () => {
       if (socket) socket.emit('itemUsed', roomId, itemId);
     }
   };
-  // Todo: 총 라운드가 끝나면 아이템 상태 초기화
 
   const isAnyItemUsedThisRound = Object.values(itemUsageState).some(
     item => item !== null && item === gameState.round
@@ -86,7 +85,9 @@ const ItemBox: React.FC = () => {
             </div>
 
             {(gameState.items[item.id as keyof typeof itemUsageState].status ||
-              isAnyItemUsedThisRound) && (
+              isAnyItemUsedThisRound ||
+              itemUsageState[item.id as keyof typeof itemUsageState] !==
+                null) && (
               <div className="absolute inset-0 flex items-center justify-center bg-black/60">
                 {itemUsageState[item.id as keyof typeof itemUsageState] !==
                   null && (

--- a/src/features/drawing/components/TimeBar.tsx
+++ b/src/features/drawing/components/TimeBar.tsx
@@ -2,46 +2,23 @@ import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 
 interface TimerBarProps {
-  duration: number;
-  onComplete: () => void;
+  deadline: number;
   isTimeCut: boolean;
 }
 
-const MIN_DURATION = 1;
-
-const TimerBar: React.FC<TimerBarProps> = ({
-  duration,
-  onComplete,
-  isTimeCut,
-}) => {
-  const [remainingDuration, setRemainingDuration] = useState(duration);
-  const [isCutActive, setIsCutActive] = useState(isTimeCut);
+const TimerBar: React.FC<TimerBarProps> = ({ deadline, isTimeCut }) => {
+  const [duration, setDuration] = useState(0);
 
   useEffect(() => {
-    // Time-Cutter 사용 시
-    if (isTimeCut && !isCutActive) {
-      const newDuration = Math.max(remainingDuration / 2, MIN_DURATION);
-      setRemainingDuration(newDuration);
-      setIsCutActive(true);
+    const calculateDuration = () => {
+      const currentTime = Date.now();
+      const remainingTime = Math.max(deadline - currentTime, 0);
 
-      const timer = setTimeout(() => {
-        onComplete();
-      }, newDuration * 1000);
+      setDuration(remainingTime / 1000);
+    };
 
-      return () => clearTimeout(timer);
-    }
-
-    // Time-Cutter가 트리거되지 않은 기본 타이머
-    const timer = setTimeout(() => {
-      onComplete();
-    }, remainingDuration * 1000);
-
-    return () => clearTimeout(timer);
-  }, [isTimeCut, onComplete, remainingDuration]);
-
-  // TODO
-  // TimeBar를 현재 시간 부터 5분으로 아이템을 사용하면 다른 부분에서 시간이 계속 바뀌면서 다른 버튼에도 영향을 가는 것으로 추측
-  // 현재 시간이 아닌 게임이 진행 시작 시간을 기준으로 작업하는게 좋아 보임.
+    calculateDuration();
+  }, [deadline]);
 
   return (
     <div className="flex items-center gap-x-[15px]">
@@ -63,26 +40,16 @@ const TimerBar: React.FC<TimerBarProps> = ({
         />
       </div>
       <div className="w-full bg-disabled h-3 rounded-full overflow-hidden relative">
-        <div
+        <motion.div
+          key={duration}
           className={`absolute top-0 left-0 h-full ${
             isTimeCut ? 'bg-fuschia' : 'bg-secondary-default'
           }`}
-          style={{
-            width: '100%',
-            animation: `shrink ${remainingDuration}s linear forwards`,
-          }}
+          initial={{ width: '100%' }}
+          animate={{ width: '0%' }}
+          transition={{ duration, ease: 'linear' }}
         />
       </div>
-      <style jsx>{`
-        @keyframes shrink {
-          from {
-            width: 100%;
-          }
-          to {
-            width: 0;
-          }
-        }
-      `}</style>
     </div>
   );
 };

--- a/src/features/drawing/components/TimeBar.tsx
+++ b/src/features/drawing/components/TimeBar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { motion } from 'framer-motion';
 
 interface TimerBarProps {
   duration: number;
@@ -45,10 +46,16 @@ const TimerBar: React.FC<TimerBarProps> = ({
   return (
     <div className="flex items-center gap-x-[15px]">
       <div className="ml-[15px]">
-        <img
+        <motion.img
           src="/images/drawing/hourglass.svg"
           alt="hourglass"
           draggable={false}
+          animate={{ rotate: 180 }}
+          transition={{
+            repeat: Infinity,
+            ease: 'easeInOut',
+            duration: 2,
+          }}
           style={{
             width: '30px',
             height: '30px',

--- a/src/features/drawing/components/ToxicEffect.tsx
+++ b/src/features/drawing/components/ToxicEffect.tsx
@@ -1,49 +1,19 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
-const toxicImagePaths = [
-  '/images/drawing/items/effects/toxic01.svg',
-  '/images/drawing/items/effects/toxic02.svg',
-  '/images/drawing/items/effects/toxic03.svg',
-  '/images/drawing/items/effects/toxic04.svg',
-  '/images/drawing/items/effects/toxic05.svg',
-  '/images/drawing/items/effects/toxic06.svg',
-  '/images/drawing/items/effects/toxic07.svg',
-];
-
-interface Position {
+export interface Position {
   src: string;
   left: number;
   top: number;
 }
 
-const ToxicEffect: React.FC = () => {
-  const [positions, setPositions] = useState<Position[]>([]);
+interface ToxicEffectProps {
+  toxicEffectPositions: Position[];
+}
 
-  useEffect(() => {
-    const step = Math.floor(80 / Math.sqrt(7));
-    let leftPos = 0;
-    let topPos = 0;
-
-    const newPositions: Position[] = Array.from({ length: 7 }, (_, i) => {
-      const src = toxicImagePaths[i % toxicImagePaths.length];
-      const left = leftPos + Math.random() * step;
-      const top = topPos + Math.random() * step;
-
-      leftPos += step;
-      if (leftPos >= 80) {
-        leftPos = 0;
-        topPos += step;
-      }
-
-      return { src, left, top };
-    });
-
-    setPositions(newPositions);
-  }, []);
-
+const ToxicEffect: React.FC<ToxicEffectProps> = ({ toxicEffectPositions }) => {
   return (
     <div className="absolute left-0 top-0 w-full h-full">
-      {positions.map((pos, index) => (
+      {toxicEffectPositions.map((pos, index) => (
         <img
           key={index}
           src={pos.src}

--- a/src/features/drawing/store/useItemStore.ts
+++ b/src/features/drawing/store/useItemStore.ts
@@ -1,11 +1,11 @@
 import { create } from 'zustand';
 
 interface ItemUsageState {
-  ToxicCover: number | null;
-  GrowingBomb: number | null;
-  PhantomReverse: number | null;
-  LaundryFlip: number | null;
-  TimeCutter: number | null;
+  toxicCover: number | null;
+  growingBomb: number | null;
+  phantomReverse: number | null;
+  laundryFlip: number | null;
+  timeCutter: number | null;
 }
 
 interface ItemStore {
@@ -16,11 +16,11 @@ interface ItemStore {
 
 const useItemStore = create<ItemStore>(set => ({
   itemUsageState: {
-    ToxicCover: null,
-    GrowingBomb: null,
-    PhantomReverse: null,
-    LaundryFlip: null,
-    TimeCutter: null,
+    toxicCover: null,
+    growingBomb: null,
+    phantomReverse: null,
+    laundryFlip: null,
+    timeCutter: null,
   },
   setItemUsed: (itemId, round) =>
     set(state => ({
@@ -32,11 +32,11 @@ const useItemStore = create<ItemStore>(set => ({
   resetItemUsageState: () =>
     set({
       itemUsageState: {
-        ToxicCover: null,
-        GrowingBomb: null,
-        PhantomReverse: null,
-        LaundryFlip: null,
-        TimeCutter: null,
+        toxicCover: null,
+        growingBomb: null,
+        phantomReverse: null,
+        laundryFlip: null,
+        timeCutter: null,
       },
     }),
 }));

--- a/src/features/socket/socketStore.ts
+++ b/src/features/socket/socketStore.ts
@@ -25,7 +25,6 @@ interface GameState {
   turnDeadline: number | null;
   correctAnswerCount: number;
   isItemsEnabled: boolean;
-  activeItem: string;
   items: Record<string, { user: string | null; status: boolean }>;
   order: string[];
   participants: Record<string, Participant>;
@@ -63,6 +62,7 @@ const useSocketStore = create<SocketStore>((set, get) => ({
     }
 
     socket.on('gameStateUpdate', (gameState: GameState) => {
+      console.log(gameState.round, gameState.turn);
       set({ gameState });
     });
 

--- a/src/features/socket/socketStore.ts
+++ b/src/features/socket/socketStore.ts
@@ -42,7 +42,6 @@ interface SocketStore {
     roomInfo?: { rounds: number; topic: string; isItemsEnabled: boolean }
   ) => void;
   disconnectSocket: () => void;
-  updateGameState: (updatedGameState: GameState) => void;
 }
 
 const useSocketStore = create<SocketStore>((set, get) => ({
@@ -78,10 +77,6 @@ const useSocketStore = create<SocketStore>((set, get) => ({
       socket.disconnect();
       set({ socket: null, roomId: null, gameState: null });
     }
-  },
-
-  updateGameState: updatedGameState => {
-    set({ gameState: updatedGameState });
   },
 }));
 

--- a/src/features/socket/socketStore.ts
+++ b/src/features/socket/socketStore.ts
@@ -62,7 +62,6 @@ const useSocketStore = create<SocketStore>((set, get) => ({
     }
 
     socket.on('gameStateUpdate', (gameState: GameState) => {
-      console.log(gameState.round, gameState.turn);
       set({ gameState });
     });
 


### PR DESCRIPTION
### 📝 관련 이슈
closed #41 

### ✨ 반영 브랜치

- FROM: `41-feat/item-socket-2`
- TO: `master`

### ✅ PR 내용

- [x] `SocketStore`의 `updateGameState` 메소드 삭제
  > - `connectSocket` 메소드의 `gameStateUpdate` 소켓이벤트가 동일한 기능 수행
  > - 서버에서 `gameStateUpdate` 이벤트 emit만 하고 클라이언트에서는 별도의 이벤트 on 함수를 적어주지 않아도 됨
  ```
    socket.on('gameStateUpdate', (gameState: GameState) => {
      set({ gameState });
    });
  ```

- [x] `ItemBox`의 `SpeechBubble`에 함께 적용되던 호버 및 클릭이벤트 수정
  > - 아이템 이미지 영역을 호버하면 생기는 `SpeechBubble`이 자식 컴포넌트라서 부모 컴포넌트의 이벤트를 위임
  > - 최상위 부모 컴포넌트가 아닌 이미지영역에만 이벤트를 적용하여 형제 컴포넌트인 `SpeechBubble`은 영역에서 제외

- [x] 아이템명 카멜케이스로 수정
  > - `public` 폴더 내 아이템 파일의 이름과 서비스 로직에서 사용되는 아이템명 동일하게 카멜케이스로 수정

- [x] `gameState`에서 `activeItem` 삭제
  > - `activeItem` 없이 `items`의 개별 `status` 값으로 아이템 효과 발동

- [x] `PhantomReverse` 기능 작업
  > - 아이템을 사용하면 서버로 `emit`하는 채팅메세지 문자열을 거꾸로 뒤집어서 전송
  ```
  const onKeyUp = (event: React.KeyboardEvent<HTMLInputElement>) => {
    if (event.key === 'Enter' && inputValue.trim() && socket) {
      const newMessage: ChatMessage = {
        nickname,
        message: inputValue,
      };

      if (gameState?.items.phantomReverse.status) {
        newMessage.message = newMessage.message.split('').reverse().join('');
      }

      socket.emit('sendMessage', roomId, newMessage);

      setInputValue('');
    }
  };
  ```

- [x] `ToxicCover` 유저간 동일 위치로 수정
  > - 아이템을 사용하면 유저간 랜덤으로 발생하는 `ToxicCover` 위치를 클라이언트가 아닌 서버가 내려주도록 수정
  > - 서버에서 내려주는 위치로 통일하여 출제자부터 정답을 맞추는 유저들까지 모두 동일하게 `ToxicCover` 이벤트 발생

- [x] `TimeCutter` 버그 수정
  > - 아이템 사용 시 시간의 반이 사라지지 않던 버그, 다른 아이템 사용에 간섭 받던 버그를 수정
  > - 서버에서 내려주는 `deadline`에 따라 `TimeBar`를 리렌더링하여 `duration` 조정
  > - 추후 `TimeBar`를 항상 100%에서 시작하지 않고 남아있는 시간이 차지하는 비율에 맞춰 수정할 예정
  ```
  const [duration, setDuration] = useState(0);

  useEffect(() => {
    const calculateDuration = () => {
      const currentTime = Date.now();
      const remainingTime = Math.max(deadline - currentTime, 0);

      setDuration(remainingTime / 1000);
    };

    calculateDuration();
  }, [deadline]);
  ```

- [x] `TimeBar` 모래시계에 애니메이션 적용
  > - 180도 회전하는 `framer-motion` 애니메이션 적용
  > - `TimeBar` 애니메이션도 기존 `keyframe`에서 `framer-motion`으로 수정
  ```
      <div className="ml-[15px]">
        <motion.img
          src="/images/drawing/hourglass.svg"
          alt="hourglass"
          draggable={false}
          animate={{ rotate: 180 }}
          transition={{
            repeat: Infinity,
            ease: 'easeInOut',
            duration: 2,
          }}
          style={{
            width: '30px',
            height: '30px',
          }}
        />
      </div>
      <div className="w-full bg-disabled h-3 rounded-full overflow-hidden relative">
        <motion.div
          key={duration}
          className={`absolute top-0 left-0 h-full ${
            isTimeCut ? 'bg-fuschia' : 'bg-secondary-default'
          }`}
          initial={{ width: '100%' }}
          animate={{ width: '0%' }}
          transition={{ duration, ease: 'linear' }}
        />
      </div>
  ```

### 🌐 테스트 배포

- [x] 테스트 배포하여 잘 동작하는 지 확인했나요?
  > - 테스트 배포 주소: https://sm.doodleplay.xyz/
  > - 테스트 환경 (OS): MacOS
  > - 테스트 환경 (Browser): Chrome / Safari / Firefox / Edge


### 📌 ETC

- 관련 서버 레포지토리: [[FEAT] 아이템 사용 소켓 추가 작업 #16](https://github.com/DoodlePlay/Server/pull/17)
- 서버 레포지토리 merge 전에는 테스트 배포 채널에서 아이템 관련 확인이 불가능합니다!
